### PR TITLE
Fix `slackin` being not executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "supertest": "0.15.0"
   },
   "bin": {
-    "slackin": "./bin/skackin"
+    "slackin": "./bin/slackin"
   }
 }


### PR DESCRIPTION
this fixes `slackin` not being an executable bin when installing via `npm install slackin`.