### PR TITLE
Typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "supertest": "0.15.0"
   },
   "bin": {
-    "slackin": "./bin/skackin"
+    "slackin": "./bin/slackin"
   }
 }


### PR DESCRIPTION
Causes the installation ot fail.

```
npm ERR! path /usr/local/lib/node_modules/slackin/bin/skackin
npm ERR! code ENOENT
```

(Nice project though. Thanks for releasing it!)