### PR TITLE
Fix bin name

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "supertest": "0.15.0"
   },
   "bin": {
-    "slackin": "./bin/skackin"
+    "slackin": "./bin/slackin"
   }
 }


### PR DESCRIPTION
```
npm ERR! argv "node" "/usr/local/bin/npm" "install" "-g" "slackin"
npm ERR! node v0.10.35
npm ERR! npm  v2.1.18
npm ERR! path /usr/local/lib/node_modules/slackin/bin/skackin
npm ERR! code ENOENT
npm ERR! errno 34

npm ERR! enoent ENOENT, chmod '/usr/local/lib/node_modules/slackin/bin/skackin'
npm ERR! enoent This is most likely not a problem with npm itself
npm ERR! enoent and is related to npm not being able to find a file.
npm ERR! enoent
```