### PR TITLE
Deploy to Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bin/slackin --token $SLACK_API_TOKEN --org $SLACK_ORG --port $PORT
+web: bin/slackin --token $SLACK_API_TOKEN --org $SLACK_ORG --port $PORT --channel $SLACK_CHANNEL

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bin/slackin --token $SLACK_API_TOKEN --org $SLACK_ORG --port $PORT --channel $SLACK_CHANNEL
+web: bin/slackin --port $PORT $SLACK_SUBDOMAIN $SLACK_API_TOKEN

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bin/slackin --token $SLACK_API_TOKEN --org $SLACK_ORG --port $PORT

--- a/Readme.md
+++ b/Readme.md
@@ -21,7 +21,7 @@ You get:
 
 ### Server
 
-`deploy to heroku button here`
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
 To launch it:
 

--- a/Readme.md
+++ b/Readme.md
@@ -27,18 +27,23 @@ To launch it:
 
 ```bash
 $ npm install -g slackin
-$ slackin --token "token" --org socketio
+$ slackin "your-slack-subdomain" "an-api-token"
 ```
 
-The available options are:
+You can find your API token at [api.slack.com/web](https://api.slack.com/web).
 
-- `--port [port]` – What port to bind to (defaults to `3000`)
-- `--token [token]` (required) – API token for your org. Get it
-[here](https://api.slack.com/web).
-- `--org [org]` (required) – Organization subdomain (//**this**.slack.com)
-- `--channel [chan]` – If you want users to join *just one guest channel* 
-  within your organization, provide it.
-- `--silent` - If provided, no errors or warnings are printed out.
+```
+  Usage: slackin [options] <slack-subdomain> <api-token>
+
+  Options:
+
+    -h, --help            output usage information
+    -V, --version         output the version number
+    -p, --port <port>     Port to listen on [$PORT or 3000]
+    -c, --channel <chan>  Single channel guest invite [$SLACK_CHANNEL]
+    -i, --interval <int>  How frequently (ms) to poll Slack [$SLACK_INTERVAL or 1000]
+    -s, --silent          Do not print out warns or errors
+```
 
 ### Realtime Badge
 

--- a/Readme.md
+++ b/Readme.md
@@ -21,28 +21,30 @@ You get:
 
 ### Server
 
+Deploy it to Heroku:
+
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
-To launch it:
+Or install and launch it locally:
 
 ```bash
 $ npm install -g slackin
-$ slackin "your-slack-subdomain" "an-api-token"
+$ slackin "your-slack-org-subdomain" "api-token"
 ```
 
-You can find your API token at [api.slack.com/web](https://api.slack.com/web).
+You can find your API token at [api.slack.com/web](https://api.slack.com/web)
 
 ```
-  Usage: slackin [options] <slack-subdomain> <api-token>
+Usage: slackin [options] <slack-subdomain> <api-token>
 
-  Options:
+Options:
 
-    -h, --help            output usage information
-    -V, --version         output the version number
-    -p, --port <port>     Port to listen on [$PORT or 3000]
-    -c, --channel <chan>  Single channel guest invite [$SLACK_CHANNEL]
-    -i, --interval <int>  How frequently (ms) to poll Slack [$SLACK_INTERVAL or 1000]
-    -s, --silent          Do not print out warns or errors
+  -h, --help            output usage information
+  -V, --version         output the version number
+  -p, --port <port>     Port to listen on [$PORT or 3000]
+  -c, --channel <chan>  Single channel guest invite [$SLACK_CHANNEL]
+  -i, --interval <int>  How frequently (ms) to poll Slack [$SLACK_INTERVAL or 1000]
+  -s, --silent          Do not print out warns or errors
 ```
 
 ### Realtime Badge

--- a/Readme.md
+++ b/Readme.md
@@ -1,12 +1,9 @@
 
 # slackin
 
-A little server that enables public access
-to a Slack server. Like Freenode, but on Slack.
+Let people invite themselves to your Slack.
 
-It prompts users to join by emailing them an
-invite to your organization (all of it or just
-one guest channel) through the Slack API.
+[![](https://cldup.com/WIbawiqp0Q.png)](http://slack.socket.io)
 
 You get:
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,21 @@
+{
+  "name": "Slackin",
+  "description": "Let people invite themselves to your Slack channel",
+  "repository": "https://github.com/rauchg/slackin",
+  "keywords": ["node", "slack"],
+  "env": {
+    "SLACK_ORG": {
+      "description": "The name of your Slack organization (**this**.slack.com)",
+      "required": true
+    },
+    "SLACK_API_TOKEN": {
+      "description": "Slack API token (you can find it on api.slack.com/web)",
+      "required": true
+    },
+    "SLACK_CHANNEL": {
+      "description": "The slack channel to invite people to",
+      "value": "general",
+      "required": false
+    }
+  }
+}

--- a/app.json
+++ b/app.json
@@ -13,8 +13,7 @@
       "required": true
     },
     "SLACK_CHANNEL": {
-      "description": "The slack channel to invite people to",
-      "value": "general",
+      "description": "Name of a single guest channel to invite them to (leave blank for a normal, all-channel invite)",
       "required": false
     }
   }

--- a/app.json
+++ b/app.json
@@ -4,12 +4,12 @@
   "repository": "https://github.com/rauchg/slackin",
   "keywords": ["node", "slack"],
   "env": {
-    "SLACK_ORG": {
-      "description": "The name of your Slack organization (**this**.slack.com)",
+    "SLACK_SUBDOMAIN": {
+      "description": "Your Slack's subdomain (**this**.slack.com)",
       "required": true
     },
     "SLACK_API_TOKEN": {
-      "description": "Slack API token (you can find it on api.slack.com/web)",
+      "description": "A Slack API token (find it on https://api.slack.com/web)",
       "required": true
     },
     "SLACK_CHANNEL": {

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "Slackin",
   "description": "Let people invite themselves to your Slack",
-  "logo": "https://i.imgur.com/odDO1Fx.png"
+  "logo": "https://i.imgur.com/odDO1Fx.png",
   "repository": "https://github.com/rauchg/slackin",
   "keywords": ["node", "slack"],
   "env": {

--- a/app.json
+++ b/app.json
@@ -1,6 +1,7 @@
 {
   "name": "Slackin",
-  "description": "Let people invite themselves to your Slack channel",
+  "description": "Let people invite themselves to your Slack",
+  "logo": "https://i.imgur.com/odDO1Fx.png"
   "repository": "https://github.com/rauchg/slackin",
   "keywords": ["node", "slack"],
   "env": {

--- a/bin/slackin
+++ b/bin/slackin
@@ -5,7 +5,7 @@ require('6to5/register');
 
 var pkg = require('../package');
 var program = require('commander');
-var slackin = require('../node');
+var slackin = require('../lib');
 
 program
 .version(pkg.version)

--- a/bin/slackin
+++ b/bin/slackin
@@ -10,9 +10,9 @@ var slackin = require('../lib');
 program
 .version(pkg.version)
 .usage('[options] <slack-subdomain> <api-token>')
-.option('-p, --port <port>', 'Port to listen on [$PORT or 3000]', parseInt, process.env.PORT || 3000)
+.option('-p, --port <port>', 'Port to listen on [$PORT or 3000]', process.env.PORT || 3000)
 .option('-c, --channel <chan>', 'Single channel guest invite [$SLACK_CHANNEL]', process.env.SLACK_CHANNEL)
-.option('-i, --interval <int>', 'How frequently (ms) to poll Slack [$SLACK_INTERVAL or 1000]', parseInt, process.env.SLACK_INTERVAL || 1000)
+.option('-i, --interval <int>', 'How frequently (ms) to poll Slack [$SLACK_INTERVAL or 1000]', process.env.SLACK_INTERVAL || 1000)
 .option('-s, --silent', 'Do not print out warns or errors')
 .parse(process.argv);
 

--- a/bin/slackin
+++ b/bin/slackin
@@ -17,8 +17,7 @@ program
 .option('-s, --silent', 'Do not print out warns or errors')
 .parse(process.argv);
 
-var port = program.port;
-slackin(program).listen(port, function(err){
+slackin(program).listen(program.port, function(err){
   if (err) throw err;
-  if (!program.silent) console.log('%s – listening on *:%d', new Date, port);
+  if (!program.silent) console.log('%s – listening on *:%d', new Date, program.port);
 });

--- a/bin/slackin
+++ b/bin/slackin
@@ -9,11 +9,11 @@ var slackin = require('../lib');
 
 program
 .version(pkg.version)
-.option('-p, --port [port]', 'Port to listen on', 3000)
-.option('-t, --token [token]', 'Token (https://api.slack.com/web)')
-.option('-o, --org [org]', 'Organization subdomain ({xxx}.slack.com)')
-.option('-c, --channel [chan]', 'Invite users only to this channel')
-.option('-i, --interval [int]', 'How frequently we poll Slack', 1000)
+.option('-p, --port <port>', 'Port to listen on', parseInt, 3000)
+.option('-t, --token <token>', 'Token (https://api.slack.com/web)')
+.option('-o, --org <org>', 'Organization subdomain ({xxx}.slack.com)')
+.option('-c, --channel <chan>', 'Invite users only to this channel')
+.option('-i, --interval <int>', 'How frequently we poll Slack', parseInt, 1000)
 .option('-s, --silent', 'Do not print out warns or errors')
 .parse(process.argv);
 

--- a/bin/slackin
+++ b/bin/slackin
@@ -9,13 +9,19 @@ var slackin = require('../lib');
 
 program
 .version(pkg.version)
-.option('-p, --port <port>', 'Port to listen on', parseInt, 3000)
-.option('-t, --token <token>', 'Token (https://api.slack.com/web)')
-.option('-o, --org <org>', 'Organization subdomain ({xxx}.slack.com)')
-.option('-c, --channel <chan>', 'Invite users only to this channel')
-.option('-i, --interval <int>', 'How frequently we poll Slack', parseInt, 1000)
+.usage('[options] <slack-subdomain> <api-token>')
+.option('-p, --port <port>', 'Port to listen on [$PORT or 3000]', parseInt, process.env.PORT || 3000)
+.option('-c, --channel <chan>', 'Single channel guest invite [$SLACK_CHANNEL]', process.env.SLACK_CHANNEL)
+.option('-i, --interval <int>', 'How frequently (ms) to poll Slack [$SLACK_INTERVAL or 1000]', parseInt, process.env.SLACK_INTERVAL || 1000)
 .option('-s, --silent', 'Do not print out warns or errors')
 .parse(process.argv);
+
+if (program.args.length != 2) {
+  program.help();
+} else {
+  program.org = program.args[0];
+  program.token = program.args[1];
+}
 
 slackin(program).listen(program.port, function(err){
   if (err) throw err;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "body-parser": "1.10.2",
     "commander": "2.6.0",
     "debug": "2.1.1",
-    "6to5": "2.13.5",
+    "6to5": "3.0.0",
     "email-regex": "1.0.0",
     "express": "4.11.0",
     "opentype.js": "0.4.4",


### PR DESCRIPTION
This adds one-click Heroku deploy:

![slackin-heroku-deploy](https://cloud.githubusercontent.com/assets/153/5972865/a8d663ac-a8b4-11e4-8a9a-65c69dbcf5ad.png)

Includes a few related (and unrelated fixes):

* Fixes the bin command so it actually works
* Changes the command line API to make subdomain and token required arguments
* Fixes optional args without values (e.g. specifying `--channel` without a value)
* Allow some options to be set with environment variables
* Adds a `Procfile` for running it on Heroku
* Adds a `app.json` and Heroku deploy button to the Readme
* Fixes 6to5 deprecation warning (upgrades to 3.0.0)