### PR TITLE
Heroku compat + more

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: make && bin/slackin --port $PORT $SLACK_SUBDOMAIN $SLACK_API_TOKEN
+web: bin/slackin --port $PORT $SLACK_SUBDOMAIN $SLACK_API_TOKEN

--- a/bin/slackin
+++ b/bin/slackin
@@ -11,7 +11,7 @@ program
 .option('-c, --channel <chan>', 'Single channel guest invite [$SLACK_CHANNEL]', process.env.SLACK_CHANNEL)
 .option('-i, --interval <int>', 'How frequently (ms) to poll Slack [$SLACK_INTERVAL or 1000]', process.env.SLACK_INTERVAL || 1000)
 .option('-s, --silent', 'Do not print out warns or errors')
-.option('-c, --css <file>', 'Full URL to a custom CSS file to use on the main page')
+.option('-c, --css <file>', 'Full URL to a custom CSS file to use on the main page', process.env.SLACKIN_CSS)
 .parse(process.argv);
 
 if (program.args.length != 2) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -55,6 +55,7 @@ export default function slackin({
     let { name, logo } = slack.org;
     let { active, total } = slack.users;
     if (!name) return res.send(404);
+    if (css) console.log(`Sending custom stylesheet at ${css}`);
     let page = dom('html',
       dom('head',
         dom('title', 'Join us on Slack!'),

--- a/lib/slack-invite.js
+++ b/lib/slack-invite.js
@@ -1,23 +1,33 @@
 
 import request from 'superagent';
+import util from 'util';
 
 export default function invite({ org, token, email, channel }, fn){
   let data = { email, token };
 
   if (channel) {
     data.channel = channel;
+    data.channels = channel;
     data.ultra_restricted = 1;
     data.set_active = true;
+    data._attempts = 1;
   }
+
+  console.log(`Requesting invite with data=${util.inspect(data)}`);
 
   request
   .post(`https://${org}.slack.com/api/users.admin.invite`)
   .type('form')
   .send(data)
   .end(function(err, res){
+    console.log(`Invitation request response: err=${err} res.status=${res.status} res.body.ok=${res.body.ok}`);
     if (err) return fn(err);
     if (200 != res.status) {
       fn(new Error(`Invalid response ${res.status}.`));
+      return;
+    }
+    if (!res.body.ok) {
+      fn(new Error(`Error inviting ${email}: ${res.body.error}.`));
       return;
     }
     fn(null);

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -39,9 +39,11 @@ export default class SlackData extends EventEmitter {
 
     if (this.channelName && !this.channel) {
       let name = this.channelName;
-      this.channel = res.body.channels.filter(chan => {
-        return name == chan.name;
-      })[0];
+      if (res.body && res.body.channels) {
+        this.channel = res.body.channels.filter(chan => {
+          return name == chan.name;
+        })[0];
+      }
 
       if (!this.channel) {
         let err = new Error(`Channel not found: "${name}"`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "slackin",
   "version": "0.3.1",
+  "scripts": {
+    "postinstall": "make"
+  },
   "description": "",
   "dependencies": {
     "babel": "4.7.1",


### PR DESCRIPTION
(Submitting per conversation in #15)

I ran into a few issues when deploying 0.3.0 to Heroku, only one of which is Heroku-specific, afaict:

* generated code in `./node` is not generated with the default buildpack, so I added a `postinstall` hook
* setting `channel` was insufficient for my uses (???) so I settled on this implementation after hacking around a bit and stealing from https://github.com/tech404/inviter
* failed invitations (sometimes?) return a 200, so checking `body.ok` is also needed