### PR TITLE
Fix for single-channel guests invitation parameter name

### DIFF
--- a/lib/slack-invite.js
+++ b/lib/slack-invite.js
@@ -5,7 +5,7 @@ export default function invite({ org, token, email, channel }, fn){
   let data = { email, token };
 
   if (channel) {
-    data.channel = channel;
+    data.channels = channel;
     data.ultra_restricted = 1;
     data.set_active = true;
   }


### PR DESCRIPTION
When try to send invitation for single-channel guests, the correct parameter name is `channels`. I confirmed to actually send the request.

![_2015-03-10_5_37_35](https://cloud.githubusercontent.com/assets/40610/6564005/b67412d2-c6e8-11e4-952c-771c1f029019.png)