### PR TITLE
svg height should be fixed, not equal to the width. fixes #24

### DIFF
--- a/lib/badge.js
+++ b/lib/badge.js
@@ -12,7 +12,7 @@ export default function badge({ total, active }){
   let rw = sep + width(value) + pad; // right side width
   let tw = lw + rw; // total width
 
-  return svg(`svg xmlns="http://www.w3.org/2000/svg" width=${tw} height=${tw}`,
+  return svg(`svg xmlns="http://www.w3.org/2000/svg" width=${tw} height=20`,
     svg(`rect rx=3 width=${tw} height=20 fill=#555`),
     svg(`rect rx=3 x=${lw} width=${rw} height=20 fill=${color}`),
     svg(`path d="M${lw} 0h${sep}v20h-${sep}z" fill=${color}`),


### PR DESCRIPTION
for some reason the `height` was set to `tw` (total width)