### PR TITLE
Fix rendering bug (NaN) in SVG

### DIFF
--- a/lib/badge.js
+++ b/lib/badge.js
@@ -34,5 +34,5 @@ function text({str, x, y}){
 
 // π=3
 function width(str){
-  return 7 * str.length;
+  return 7 * String(str).length;
 }

--- a/lib/badge.js
+++ b/lib/badge.js
@@ -7,7 +7,7 @@ const pad = 8; // left / right padding
 const sep = 4; // middle separation
 
 export default function badge({ total, active }){
-  let value = active ? `${active}/${total}` : (total || '–');
+  let value = active ? `${active}/${total}` : ('' + total || '–');
   let lw = pad + width(title) + sep; // left side width
   let rw = sep + width(value) + pad; // right side width
   let tw = lw + rw; // total width
@@ -34,5 +34,5 @@ function text({str, x, y}){
 
 // π=3
 function width(str){
-  return 7 * String(str).length;
+  return 7 * str.length;
 }


### PR DESCRIPTION
I noticed that sometimes™ the SVG badge wasn't rendered correctly. The SVG source made it very obvious what's wrong; [the `rw` variable](https://github.com/rauchg/slackin/blob/7e7f033ddb706056f4e1a66dce971afeda345b0e/lib/badge.js#L12) was `NaN`.

The only part that's not hardcoded is `width(value)`. The width function is quite simple, but value is a bit more "complicated":

If there are any `active` users, return a string showing "active/total" users, otherwise return the total users, or "-" of there's none.

So if there's 0 active users, but any total users, you'd end up calling `.length` on a Number (= `undefined`) and multiplicate that by 7 (= `NaN`).

-----

This tremendous PR should fix that