### PR TITLE
Working Dockerfile and slightly adjusted Procfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM octohost/nodejs
+
+ENV PORT 3000
+
+ADD . /srv/www
+
+WORKDIR /srv/www
+
+RUN npm install
+
+RUN make
+
+EXPOSE 3000
+
+CMD ./bin/slackin --channel $SLACK_CHANNEL --port $PORT $SLACK_SUBDOMAIN $SLACK_API_TOKEN

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: make && bin/slackin --port $PORT $SLACK_SUBDOMAIN $SLACK_API_TOKEN -c $SLACK_CHANNEL
+web: make && bin/slackin --channel $SLACK_CHANNEL --port $PORT $SLACK_SUBDOMAIN $SLACK_API_TOKEN

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: make && bin/slackin --port $PORT $SLACK_SUBDOMAIN $SLACK_API_TOKEN
+web: make && bin/slackin --port $PORT $SLACK_SUBDOMAIN $SLACK_API_TOKEN -c $SLACK_CHANNEL


### PR DESCRIPTION
This Dockerfile is the simplest way to get slackin running on Docker.

It's running here: https://slackin.octohost.io/

You can try the Docker build with:

```
docker pull octohost/slackin
docker run -d -P -e SLACK_CHANNEL=channel -e SLACK_SUBDOMAIN=subdomain -e SLACK_API_TOKEN=api-token-goes-here octohost/slackin:0.4.0
```
It will be listening on port 3000 - Docker will likely assign a random 49xxx port on the outside.