### PR TITLE
Return an error when the token account is not an admin

### DIFF
--- a/lib/slack-invite.js
+++ b/lib/slack-invite.js
@@ -20,6 +20,17 @@ export default function invite({ org, token, email, channel }, fn){
       fn(new Error(`Invalid response ${res.status}.`));
       return;
     }
+
+    // If the account that owns the token is not admin, Slack will oddly
+    // return `200 OK`, and provide other information in the body. So we
+    // need to check for the correct account scope and call the callback
+    // with an error if it's not high enough.
+    let {ok, error: providedError, needed} = res.body;
+    if (!ok && providedError === 'missing_scope' && needed === 'admin') {
+      fn(new Error(`Missing admin scope: The token you provided is for an account that is not an admin. You must provide a token from an admin account in order to invite users through the Slack API.`));
+      return;
+    }
+
     fn(null);
   });
 }


### PR DESCRIPTION
I ran into this problem when trying to setup slackin for a group I'm a member of. When I deployed to Heroku and input my Slack subdomain and token, the success message appears ("Woot! Check your email!"), but no email arrives. I wasn't using single-channel mode. After debugging, I noticed that Slack returns a `200 OK` even if the account owning the API token is not an admin. This pull request returns an error in that case.

Note that I'm not a node dev, so I'm really not sure of the correct way to handle this. Let me know if there's a better way.