### PR TITLE
add Slack favicon and better title tag

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,8 +57,11 @@ export default function slackin({
     if (!name) return res.send(404);
     let page = dom('html',
       dom('head',
-        dom('title', 'Join us on Slack!'),
+        dom('title',
+          'Join ', name, ' on Slack!'
+        ),
         dom('meta name=viewport content="width=device-width,initial-scale=1.0,minimum-scale=1.0,user-scalable=no"'),
+        dom('link rel="shortcut icon" href=https://slack.global.ssl.fastly.net/272a/img/icons/favicon-32.png'),
         css && dom('link rel=stylesheet', { href: css })
       ),
       splash({ css, name, logo, channel, active, total })


### PR DESCRIPTION
It would be better for SEO to have the title tag use the name variable and say for example "Join Project SAFE on Slack!" instead of "Join us on Slack!".

And we can put a Slack favicon instead of having nothing. I am not sure what image to use though.
In the commit, I put https://slack.global.ssl.fastly.net/272a/img/icons/favicon-32.png but it could also be https://slack.com/favicon.ico or something else.

Let me know what you think.

And thank you very much for making this :smile: !
I use it for https://slack.projectsafe.community.