### PR TITLE
Add Cache-Control: no-cache to prevent GitHub camo caching

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -122,6 +122,7 @@ export default function slackin({
   // badge rendering
   app.get('/badge.svg', (req, res) => {
     res.type('svg');
+    res.set('Cache-Control', 'no-cache');
     res.send(badge(slack.users).toHTML());
   });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -123,6 +123,7 @@ export default function slackin({
   app.get('/badge.svg', (req, res) => {
     res.type('svg');
     res.set('Cache-Control', 'max-age=0, no-cache');
+    res.set('Pragma', 'no-cache');
     res.send(badge(slack.users).toHTML());
   });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -122,7 +122,7 @@ export default function slackin({
   // badge rendering
   app.get('/badge.svg', (req, res) => {
     res.type('svg');
-    res.set('Cache-Control', 'no-cache');
+    res.set('Cache-Control', 'max-age=0, no-cache');
     res.send(badge(slack.users).toHTML());
   });
 


### PR DESCRIPTION
I've had problems with GitHub's [camo](https://github.com/atmos/camo) service aggressively caching badge.svg, preventing it from updating on README.md files.

Adding the `Cache-Control` header _should_ prevent GitHub from caching the badge.

See https://help.github.com/articles/why-do-my-images-have-strange-urls/#an-image-that-changed-recently-is-not-updating