### PR TITLE
handle responses with `ok: false`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,7 @@ export default function slackin({
     if (channel && !slack.channel) {
       return res
       .status(500)
-      .send({ msg: `Channel not found "${channel}"` });
+      .json({ msg: `Channel not found "${channel}"` });
     }
 
     let email = req.body.email;
@@ -83,13 +83,13 @@ export default function slackin({
     if (!email) {
       return res
       .status(400)
-      .send({ msg: 'No email provided' });
+      .json({ msg: 'No email provided' });
     }
 
     if (!remail().test(email)) {
       return res
       .status(400)
-      .send({ msg: 'Invalid email' });
+      .json({ msg: 'Invalid email' });
     }
 
     let chanId = slack.channel ? slack.channel.id : null;
@@ -97,9 +97,12 @@ export default function slackin({
       if (err) {
         return res
         .status(400)
-        .send({ msg: err.message });
+        .json({ msg: err.message });
       }
-      res.status(200).end();
+
+      res
+      .status(200)
+      .json({ msg: 'success' });
     });
   });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -94,7 +94,11 @@ export default function slackin({
 
     let chanId = slack.channel ? slack.channel.id : null;
     invite({ token, org, email, channel: chanId }, function(err){
-      if (err) return next(err);
+      if (err) {
+        return res
+        .status(400)
+        .send({ msg: err.message });
+      }
       res.status(200).end();
     });
   });

--- a/lib/slack-invite.js
+++ b/lib/slack-invite.js
@@ -26,8 +26,12 @@ export default function invite({ org, token, email, channel }, fn){
     // need to check for the correct account scope and call the callback
     // with an error if it's not high enough.
     let {ok, error: providedError, needed} = res.body;
-    if (!ok && providedError === 'missing_scope' && needed === 'admin') {
-      fn(new Error(`Missing admin scope: The token you provided is for an account that is not an admin. You must provide a token from an admin account in order to invite users through the Slack API.`));
+    if (!ok) {
+      if (providedError === 'missing_scope' && needed === 'admin') {
+        fn(new Error(`Missing admin scope: The token you provided is for an account that is not an admin. You must provide a token from an admin account in order to invite users through the Slack API.`));
+      } else {
+        fn(new Error(providedError));
+      }
       return;
     }
 

--- a/package.json
+++ b/package.json
@@ -15,12 +15,13 @@
     "vd": "0.1.0"
   },
   "devDependencies": {
-    "browserify": "8.1.1",
-    "mocha": "2.1.0",
-    "supertest": "0.15.0"
+    "mocha": "^2.2.4"
   },
   "main": "./node/index",
   "bin": {
     "slackin": "./bin/slackin"
+  },
+  "scripts": {
+    "test": "mocha --compilers js:babel/register"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "devDependencies": {
     "mocha": "^2.2.4",
-    "nock": "^0.48.1"
+    "nock": "^0.48.1",
+    "supertest": "^0.15.0"
   },
   "main": "./node/index",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "slackin": "./bin/slackin"
   },
   "scripts": {
-    "test": "mocha --compilers js:babel/register"
+    "test": "mocha"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "vd": "0.1.0"
   },
   "devDependencies": {
-    "mocha": "^2.2.4"
+    "mocha": "^2.2.4",
+    "nock": "^0.48.1"
   },
   "main": "./node/index",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "vd": "0.1.0"
   },
   "devDependencies": {
-    "mocha": "^2.2.4",
-    "nock": "^0.48.1",
-    "supertest": "^0.15.0"
+    "mocha": "2.2.4",
+    "nock": "0.48.1",
+    "supertest": "0.15.0"
   },
   "main": "./node/index",
   "bin": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,38 @@
+import nock from 'nock';
+import request from 'supertest';
+import slackin from '../lib/index';
 
-describe('', () => {
+describe('slackin', () => {
+  describe('POST /invite', () => {
+    it("returns success for a successful invite", (done) => {
+      let opts = {
+        token: 'mytoken',
+        org: 'myorg'
+      };
 
+      // TODO simplify mocking
+      nock(`https://${opts.org}.slack.com`)
+        .get('/api/rtm.start?token=mytoken')
+        .reply(200, {
+          team: {
+            name: 'myteam',
+            icon: {}
+          },
+          users: [{}]
+        });
+
+      nock(`https://${opts.org}.slack.com`)
+        .post('/api/users.admin.invite')
+        .reply(200, { ok: true });
+
+      let app = slackin(opts);
+
+      request(app)
+        .post('/invite')
+        .send({ email: 'foo@example.com' })
+        // .expect('Content-Type', /json/)
+        .expect(200, {})
+        .end(done);
+    });
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -33,8 +33,8 @@ describe('slackin', () => {
       request(app)
         .post('/invite')
         .send({ email: 'foo@example.com' })
-        // .expect('Content-Type', /json/)
-        .expect(200, {})
+        .expect('Content-Type', /json/)
+        .expect(200, { msg: 'success' })
         .end(done);
     });
 
@@ -58,7 +58,7 @@ describe('slackin', () => {
       request(app)
         .post('/invite')
         .send({ email: 'foo@example.com' })
-        // .expect('Content-Type', /json/)
+        .expect('Content-Type', /json/)
         .expect(400, { msg: "other error" })
         .end(done);
     });

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--require ./test/setup

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,2 @@
+--compilers js:babel/register
 --require ./test/setup

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,0 @@
---require 6to5/register

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,5 @@
+import nock from 'nock';
+
+nock.disableNetConnect();
+// allow websockets
+nock.enableNetConnect(/127\.0\.0\.1:\d+/);

--- a/test/slack-invite.js
+++ b/test/slack-invite.js
@@ -1,0 +1,20 @@
+import assert from 'assert';
+import invite from '../lib/slack-invite';
+
+describe('slack-invite', () => {
+  describe('.invite()', () => {
+    it("succeeds when ok", (done) => {
+      var opts = {
+        channel: 'mychannel',
+        email: 'user@example.com',
+        org: 'myorg',
+        token: 'mytoken'
+      };
+
+      invite(opts, (err) => {
+        assert.equal(err, null);
+        done();
+      });
+    });
+  });
+});

--- a/test/slack-invite.js
+++ b/test/slack-invite.js
@@ -1,3 +1,4 @@
+import nock from 'nock';
 import assert from 'assert';
 import invite from '../lib/slack-invite';
 
@@ -10,6 +11,8 @@ describe('slack-invite', () => {
         org: 'myorg',
         token: 'mytoken'
       };
+
+      nock(`https://${opts.org}.slack.com`).post('/api/users.admin.invite').reply(200);
 
       invite(opts, (err) => {
         assert.equal(err, null);

--- a/test/slack-invite.js
+++ b/test/slack-invite.js
@@ -4,18 +4,39 @@ import invite from '../lib/slack-invite';
 
 describe('slack-invite', () => {
   describe('.invite()', () => {
-    it("succeeds when ok", (done) => {
-      var opts = {
+    var opts;
+
+    before(() => {
+      opts = {
         channel: 'mychannel',
         email: 'user@example.com',
         org: 'myorg',
         token: 'mytoken'
       };
+    });
 
-      nock(`https://${opts.org}.slack.com`).post('/api/users.admin.invite').reply(200);
+    it("succeeds when ok", (done) => {
+      nock(`https://${opts.org}.slack.com`).
+        post('/api/users.admin.invite').
+        reply(200, { ok: true });
 
       invite(opts, (err) => {
         assert.equal(err, null);
+        done();
+      });
+    });
+
+    it("passes along an error message", (done) => {
+      nock(`https://${opts.org}.slack.com`).
+        post('/api/users.admin.invite').
+        reply(200, {
+          ok: false,
+          error: "other error"
+        });
+
+      invite(opts, (err) => {
+        assert.notEqual(err, null);
+        assert.equal(err.message, "other error");
         done();
       });
     });


### PR DESCRIPTION
In trying to debug https://github.com/rauchg/slackin/issues/38, finally found that there was an error condition that wasn't being handled:
 
![screen shot 2015-04-27 at 4 30 11 pm](https://cloud.githubusercontent.com/assets/86842/7385096/31f50560-ee0d-11e4-9bd5-db0a752f9182.png)

This PR:

* Handles a JSON response from the Slack invite API where the `ok` property is `false`
* Fixes passing of error messages to client
* Adds tests

/cc @ultrasaurus