### PR TITLE
Add basic Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+sudo: false
+before_script: make
+script:
+- npm test
+- bin/slackin --help


### PR DESCRIPTION
Travis CI proudly uses Slackin at https://chat.travis-ci.com/ , fwiw :smiley_cat:

For full effect, this will also require the equivalent of:

``` bash
gem install travis
travis enable -r rauchg/slackin
```