### PR TITLE
Allow hosting at a subfolder

### DIFF
--- a/lib/assets/client.js
+++ b/lib/assets/client.js
@@ -48,8 +48,11 @@ function invite(channel, email, fn){
   });
 }
 
+// use dom element for better cross browser compatibility
+var url = document.createElement('a');
+url.href = window.location;
 // realtime updates
-var socket = io();
+var socket = io({path: (url.pathname + '/socket.io').replace('//','/')});
 socket.on('data', function(users){
   for (var i in users) update(i, users[i]);
 });

--- a/lib/assets/iframe.js
+++ b/lib/assets/iframe.js
@@ -52,7 +52,11 @@
   var script = document.createElement('script');
   script.src = 'https://cdn.socket.io/socket.io-1.3.2.js';
   script.onload = function(){
-    var socket = io();
+
+    // use dom element for better cross browser compatibility
+    var url = document.createElement('a');
+    url.href = window.location;
+    var socket = io({path: (url.pathname + '/socket.io').replace('//','/')});
     var count = document.getElementsByClassName('slack-count')[0];
 
     socket.on('data', function(users){

--- a/lib/splash.js
+++ b/lib/splash.js
@@ -39,8 +39,8 @@ export default function splash({ name, logo, active, total, channels, iframe }){
     style({ logo, active, iframe }),
     // xxx: single build
     dom('script src=https://cdn.socket.io/socket.io-1.3.2.js'),
-    dom('script src=/assets/superagent.js'),
-    dom('script src=/assets/client.js')
+    dom('script src=assets/superagent.js'),
+    dom('script src=assets/client.js')
   );
   return div;
 }
@@ -97,7 +97,7 @@ function style({ logo, active, iframe } = {}){
     });
 
     css.add('.logo.slack', {
-      'background-image': 'url(/assets/slack.svg)'
+      'background-image': 'url(assets/slack.svg)'
     });
 
     if (logo) {


### PR DESCRIPTION
To host at mydomain.com/getslack, can't use absolute urls. Also,
socket.io needs to be initialized with the proper path.

Sample nginx config to host in a subfolder:

```
location /getslack/ {
    proxy_pass http://localhost:3000/;
    proxy_set_header Host $host;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    # upgrade needed for websocket connection
    proxy_http_version 1.1;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection "upgrade";
}
```