### PR TITLE
Standardize use of example host

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -56,13 +56,13 @@ Workaround: sign up for a free org, and set up Slackin to point to it
 [![](https://cldup.com/IaiPnDEAA6.gif)](http://slack.socket.io)
 
 ```html
-<script async defer src="http://slackin.yourhost.com/slackin.js"></script>
+<script async defer src="http://slack.yourdomain.com/slackin.js"></script>
 ```
 
 or for the large version, append `?large`:
 
 ```html
-<script async defer src="http://slackin.yourhost.com/slackin.js?large"></script>
+<script async defer src="http://slack.yourdomain.com/slackin.js?large"></script>
 ```
 
 ### SVG
@@ -70,14 +70,14 @@ or for the large version, append `?large`:
 [![](https://cldup.com/jWUT4QFLnq.png)](http://slack.socket.io)
 
 ```html
-<img src="http://slackin.yourhost.com/badge.svg">
+<img src="http://slack.yourdomain.com/badge.svg">
 ```
 
 ### Landing page
 
 [![](https://cldup.com/WIbawiqp0Q.png)](http://slack.socket.io)
 
-Point to `http://slackin.yourhost.com`.
+Point to `http://slack.yourdomain.com`.
 
 **Note:** the image for the logo of the landing page
 is retrieved from the Slack API. If your organization


### PR DESCRIPTION
Updated all http://slackin.yourhost.com references to http://slack.yourdomain.com to match the first example.