### PR TITLE
Added safety check for channels.

### DIFF
--- a/lib/slack.js
+++ b/lib/slack.js
@@ -44,7 +44,7 @@ export default class SlackData extends EventEmitter {
 
     // reset the list of channels
     this.channelsByName = {};
-    res.body.channels.forEach(channel => {
+    (res.body.channels || []).forEach(channel => {
       this.channelsByName[channel.name] = channel;
     });
 


### PR DESCRIPTION
I'm eventually facing downtime issues with slackin service. Whenever I check the logs I see that are some requests being sent without the __channels__ attribute.

This pull request aims to do a safety fallback to an empty array in case the channels property is not in the request body.