### PR TITLE
Optional checkbox for code of conduct agreement

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -41,6 +41,7 @@ Options:
   -V, --version            output the version number
   -p, --port <port>        Port to listen on [$PORT or 3000]
   -c, --channels [<chan>]  One or more comma-separated channel names to allow single-channel guests [$SLACK_CHANNELS]
+  -C, --coc <link>         URL to your code of conduct
   -i, --interval <int>     How frequently (ms) to poll Slack [$SLACK_INTERVAL or 1000]
   -s, --silent             Do not print out warns or errors
 ```

--- a/app.json
+++ b/app.json
@@ -16,6 +16,10 @@
     "SLACK_CHANNEL": {
       "description": "Name of a single guest channel to invite them to (leave blank for a normal, all-channel invite). In order to make this work, you have to have a paid account. You'll only be able to invite as many people as your number of paying members times 5.",
       "required": false
+    },
+    "SLACK_COC": {
+      "description": "URL to your code of conduct",
+      "required": false
     }
   }
 }

--- a/bin/slackin
+++ b/bin/slackin
@@ -10,6 +10,7 @@ program
 .option('-p, --port <port>', 'Port to listen on [$PORT or 3000]', process.env.PORT || 3000)
 .option('-c, --channels [<chan>]', 'One or more comma-separated channel names to allow single-channel guests [$SLACK_CHANNELS]', process.env.SLACK_CHANNELS)
 .option('-c, --channel <chan>', 'Single channel guest invite (deprecated) [$SLACK_CHANNEL]', process.env.SLACK_CHANNEL)
+.option('-C, --coc <link>', 'URL to your code of conduct [$SLACK_COC]', process.env.SLACK_COC)
 .option('-i, --interval <int>', 'How frequently (ms) to poll Slack [$SLACK_INTERVAL or 1000]', process.env.SLACK_INTERVAL || 1000)
 .option('-s, --silent', 'Do not print out warns or errors')
 .option('-c, --css <file>', 'Full URL to a custom CSS file to use on the main page')

--- a/lib/assets/badge.js
+++ b/lib/assets/badge.js
@@ -106,6 +106,7 @@
     div.style.borderRadius = '4px';
     div.style.padding = '4px';
     div.style.boxSizing = 'content-box';
+    div.style.transition = div.style.WebkitTransition = 'height 0.15s ease-out';
 
     // new iframe
     var ni = document.createElement('iframe');
@@ -113,8 +114,22 @@
     ni.style.width = '250px';
     ni.style.height = '124px';
     ni.style.borderWidth = 0;
+    ni.style.visibility = 'hidden';
+    ni.style.transition = ni.style.WebkitTransition = 'height 0.15s ease-out';
     ni.src = iframe.src.replace(/\?.*/, '') + '/dialog';
     ni.onload = function(){
+      var id = Math.random() * (1 << 24) | 0;
+      ni.contentWindow.postMessage('slackin:' + id, '*');
+      window.addEventListener('message', function onmsg(e){
+        var hp = 'slackin-dialog-height:' + id + ':';
+        if (hp == e.data.substr(0, hp.length)) {
+          var height = e.data.substr(hp.length);
+          ni.style.height = height + 'px';
+          div.style.height = height + 'px';
+          ni.style.visibility = 'visible';
+        }
+      });
+
       window.addEventListener('scroll', dposition);
       window.addEventListener('resize', dposition);
       position();

--- a/lib/assets/client.js
+++ b/lib/assets/client.js
@@ -37,6 +37,14 @@ if (cocAgreement) {
   });
 }
 
+window.addEventListener('message', function onmsg(e){
+  if (/^slackin:/.test(e.data)) {
+    var id = e.data.replace(/^slackin:/, '');
+    var h = body.scrollHeight;
+    window.parent.postMessage('slackin-dialog-height:' + id + ':' + h, '*');
+  }
+});
+
 function invite(channel, email, fn){
   request
   .post('/invite')

--- a/lib/assets/client.js
+++ b/lib/assets/client.js
@@ -15,6 +15,10 @@ button.className = '';
 // capture submit
 body.addEventListener('submit', function(ev){
   ev.preventDefault();
+  if (cocAgreement && !cocAgreement.checked) {
+    // require code of conduct agreement
+    return;
+  }
   button.disabled = true;
   button.className = '';
   button.innerHTML = 'Please Wait';

--- a/lib/assets/client.js
+++ b/lib/assets/client.js
@@ -5,8 +5,9 @@ var request = superagent;
 
 // elements
 var select = body.querySelector('select');
-var input = body.querySelector('input');
+var input = body.querySelector('input[type=email]');
 var button = body.querySelector('button');
+var cocAgreement = body.querySelector('#coc-agreement');
 
 // remove loading state
 button.className = '';
@@ -30,6 +31,11 @@ body.addEventListener('submit', function(ev){
   });
 });
 
+if (cocAgreement) {
+  cocAgreement.addEventListener('change', function(ev){
+    button.disabled = cocAgreement.checked ? false : true;
+  });
+}
 
 function invite(channel, email, fn){
   request

--- a/lib/index.js
+++ b/lib/index.js
@@ -137,7 +137,7 @@ export default function slackin({
     let { name } = slack.org;
     let { active, total } = slack.users;
     if (!name) return res.send(404);
-    let dom = splash({ name, channels, active, total, iframe: true });
+    let dom = splash({ name, channels, active, total, iframe: true, coc });
     res.type('html');
     res.send(dom.toHTML());
   });

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,7 @@ export default function slackin({
   org,
   css,
   channels,
+  coc,
   silent = false // jshint ignore:line
 }){
   // must haves
@@ -70,7 +71,7 @@ export default function slackin({
         dom('link rel="shortcut icon" href=https://slack.global.ssl.fastly.net/272a/img/icons/favicon-32.png'),
         css && dom('link rel=stylesheet', { href: css })
       ),
-      splash({ css, name, logo, channels, active, total })
+      splash({ css, name, logo, channels, active, total, coc })
     );
     res.type('html');
     res.send(page.toHTML());

--- a/lib/splash.js
+++ b/lib/splash.js
@@ -1,7 +1,7 @@
 
 import dom from 'vd';
 
-export default function splash({ name, logo, active, total, channels, iframe }){
+export default function splash({ name, logo, active, total, channels, iframe, coc }){
   let div = dom('.splash',
     !iframe && dom('.logos',
       logo && dom('.logo.org'),
@@ -30,7 +30,10 @@ export default function splash({ name, logo, active, total, channels, iframe }){
       ),
       dom('input.form-item type=email placeholder=you@yourdomain.com '
         + (!iframe ? 'autofocus' : '')),
-      dom('button.loading', 'Get my Invite')
+      coc && dom('label',
+        dom('input type=checkbox id=coc-agreement value=agreed'),
+        'I agree to the ', dom(`a href=${coc} target=_blank`, 'code of conduct')),
+      dom('button.loading' + (coc ? ' disabled' : ''), 'Get my Invite')
     ),
     !iframe && dom('footer',
       'powered by ',
@@ -148,6 +151,22 @@ function style({ logo, active, iframe } = {}){
     'text-align': 'center',
     'box-sizing': 'border-box',
     'width': '100%'
+  });
+
+  css.add('label', {
+    'font-size': '15px',
+    'height': '24px',
+    'line-height': '24px',
+    'margin-top': iframe ? '5px' : '10px',
+    'vertical-align': 'middle',
+    'text-align': 'left',
+    'display': 'block',
+    'box-sizing': 'border-box',
+    'width': '100%'
+  });
+
+  css.add('label input[type=checkbox]', {
+    'margin-right': '5px'
   });
 
   css.add('button', {

--- a/lib/splash.js
+++ b/lib/splash.js
@@ -219,20 +219,20 @@ function style({ logo, active, iframe } = {}){
     'margin-bottom': '0'
   });
 
-  css.add('input', {
+  css.add('input[type=email]', {
     'color': '#9B9B9B',
     'border': '1px solid #D6D6D6'
   });
 
   if (iframe) {
-    css.add('input, button', {
+    css.add('input[type=email], button', {
       'font-size': '11px',
       'height': '28px',
       'line-height': '28px'
     });
   }
 
-  css.add('input:focus', {
+  css.add('input[type=email]:focus', {
     'color': '#666',
     'border-color': '#999',
     'outline': '0'

--- a/lib/splash.js
+++ b/lib/splash.js
@@ -154,11 +154,10 @@ function style({ logo, active, iframe } = {}){
   });
 
   css.add('label', {
-    'font-size': '15px',
+    'font-size': iframe ? '12px' : '15px',
     'height': '24px',
     'line-height': '24px',
     'margin-top': iframe ? '5px' : '10px',
-    'vertical-align': 'middle',
     'text-align': 'left',
     'display': 'block',
     'box-sizing': 'border-box',


### PR DESCRIPTION
Thanks for making and maintaining this project! In this PR I’ve implemented an option for a checkbox that ensures the user agrees to a linked code of conduct before requesting an invite. You can see it in action on the [TucsonJS slackin](http://chat.tucsonjs.org/). I suspect many other users of slackin may find this feature helpful.

Some notes on the implementation: Adding the option for the checkbox was relatively straightforward in the main interface, however it did add some complications with the badge dialog interface. The fact that the checkbox is optional causes the dialog to be of variable height, so I made the dialog adjust itself to the height of its content before showing itself (using the same methodology the badge uses to adjust its width).

Thanks for considering! Let me know if there is something I should have done differently.