### PR TITLE
Add already registered link

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,7 +70,7 @@ export default function slackin({
         dom('link rel="shortcut icon" href=https://slack.global.ssl.fastly.net/272a/img/icons/favicon-32.png'),
         css && dom('link rel=stylesheet', { href: css })
       ),
-      splash({ css, name, logo, channels, active, total })
+      splash({ css, name, org, logo, channels, active, total })
     );
     res.type('html');
     res.send(page.toHTML());

--- a/lib/slack-invite.js
+++ b/lib/slack-invite.js
@@ -29,6 +29,10 @@ export default function invite({ org, token, email, channel }, fn){
     if (!ok) {
       if (providedError === 'missing_scope' && needed === 'admin') {
         fn(new Error(`Missing admin scope: The token you provided is for an account that is not an admin. You must provide a token from an admin account in order to invite users through the Slack API.`));
+      } else if (providedError === 'already_invited') {
+        fn(new Error('You have already been invited to slack. Check for an email from feedback@slack.com.'));
+      } else if (providedError === 'already_in_team') {
+        fn(new Error(`Already invited. Sign in at https://${org}.slack.com.`));
       } else {
         fn(new Error(providedError));
       }

--- a/lib/splash.js
+++ b/lib/splash.js
@@ -1,7 +1,7 @@
 
 import dom from 'vd';
 
-export default function splash({ name, logo, active, total, channels, iframe }){
+export default function splash({ name, org, logo, active, total, channels, iframe }){
   let div = dom('.splash',
     !iframe && dom('.logos',
       logo && dom('.logo.org'),
@@ -31,6 +31,10 @@ export default function splash({ name, logo, active, total, channels, iframe }){
       dom('input.form-item type=email placeholder=you@yourdomain.com '
         + (!iframe ? 'autofocus' : '')),
       dom('button.loading', 'Get my Invite')
+    ),
+    !iframe && dom('p.signin',
+      'Already registered? ',
+      dom(`a href=https://${org}.slack.com`, 'Sign in.')
     ),
     !iframe && dom('footer',
       'powered by ',
@@ -223,6 +227,21 @@ function style({ logo, active, iframe } = {}){
   if (active) {
     css.add('.active', {
       'color': pink
+    });
+  }
+
+  if (!iframe) {
+    css.add('p.signin', {
+      'font-size': '12px'
+    });
+
+    css.add('p.signin a', {
+      'color': pink,
+      'text-decoration': 'none'
+    });
+
+    css.add('p.signin a:hover', {
+      'background-color': '#9B9B9B'
     });
   }
 

--- a/lib/splash.js
+++ b/lib/splash.js
@@ -144,14 +144,13 @@ function style({ logo, active, iframe } = {}){
 
   css.add('button, .form-item', {
     'font-size': '12px',
-    'height': '32px',
-    'line-height': '32px',
     'margin-top': iframe ? '5px' : '10px',
     'vertical-align': 'middle',
     'display': 'block',
     'text-align': 'center',
     'box-sizing': 'border-box',
-    'width': '100%'
+    'width': '100%',
+    'padding': '9px'
   });
 
   css.add('button', {
@@ -163,7 +162,6 @@ function style({ logo, active, iframe } = {}){
     'cursor': 'pointer',
     'appearence': 'none',
     '-webkit-appearence': 'none',
-    'padding': '0',
     'outline': '0',
     'transition': 'background-color 150ms ease-in, color 150ms ease-in'
   });
@@ -180,7 +178,8 @@ function style({ logo, active, iframe } = {}){
   });
 
   css.add('button.error', {
-    'background-color': '#F4001E'
+    'background-color': '#F4001E',
+    'text-transform': 'none'
   });
 
   css.add('button.success:disabled', {

--- a/lib/splash.js
+++ b/lib/splash.js
@@ -33,8 +33,9 @@ export default function splash({ name, org, logo, active, total, channels, ifram
       dom('button.loading', 'Get my Invite')
     ),
     !iframe && dom('p.signin',
-      'Already registered? ',
-      dom(`a href=https://${org}.slack.com`, 'Sign in.')
+      'or ',
+      dom(`a href=https://${org}.slack.com`, 'sign in'),
+      '.'
     ),
     !iframe && dom('footer',
       'powered by ',
@@ -231,7 +232,8 @@ function style({ logo, active, iframe } = {}){
 
   if (!iframe) {
     css.add('p.signin', {
-      'font-size': '12px'
+      'padding': '10px 0 10px',
+      'font-size': '11px'
     });
 
     css.add('p.signin a', {


### PR DESCRIPTION
If you wind up back at the page to request an invite and input your address again, slack raises an error because you're already on the team. This adds a link below the signup button to take you back to Slack when you're already registered.