### PR TITLE
Build process and Heroku improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ WORKDIR /srv/www
 
 RUN npm install
 
-RUN make
-
 EXPOSE 3000
 
 CMD ./bin/slackin --channels $SLACK_CHANNELS --port $PORT $SLACK_SUBDOMAIN $SLACK_API_TOKEN

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ ADD . /srv/www
 
 WORKDIR /srv/www
 
-RUN npm install
+RUN npm install --unsafe-perm
 
 EXPOSE 3000
 
-CMD ./bin/slackin --channels $SLACK_CHANNELS --port $PORT $SLACK_SUBDOMAIN $SLACK_API_TOKEN
+CMD ./bin/slackin --channels "$SLACK_CHANNELS" --port $PORT $SLACK_SUBDOMAIN $SLACK_API_TOKEN

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,23 @@
+INJS = $(wildcard lib/*.js)
+OUTJS = $(subst lib/,node/,$(INJS))
+
+INASSETS = $(wildcard lib/assets/*)
+OUTASSETS = $(subst lib/assets/,node/assets/,$(INASSETS))
 
 BABEL = ./node_modules/.bin/babel
 
-all: node
+.PHONY: clean
 
-node: lib
-	@mkdir -p node/assets/
-	@rm -rf node/assets/*
-	@cp -r lib/assets node/
-	@for path in lib/*.js; do \
-		file=`basename $$path`; \
-		$(BABEL) "lib/$$file" > "node/$$file"; \
-	done
+all: node/assets $(OUTJS) $(OUTASSETS)
+
+clean:
+	rm -rf node/
+
+node/assets/% : lib/assets/%
+	cp $^ $@
+
+node/%.js: lib/%.js
+	$(BABEL) $^ > $@
+
+node/assets:
+	mkdir -p node/assets/

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: make && bin/slackin --channels "$SLACK_CHANNELS" --port $PORT $SLACK_SUBDOMAIN $SLACK_API_TOKEN
+web: bin/slackin --channels "$SLACK_CHANNELS" --port $PORT $SLACK_SUBDOMAIN $SLACK_API_TOKEN

--- a/Readme.md
+++ b/Readme.md
@@ -104,6 +104,20 @@ online users you have on the console.
 
 By default logging is enabled.
 
+## Developing
+
+Slackin's server side code is written in ES6. It uses babel to transpile the 
+ES6 code to a format node understands. After cloning Slackin, you should 
+install the prerequisite node libraries with npm:
+
+```bash
+$ npm install
+```
+
+After the libraries install, the postinstall script will run make to invoke
+babel on the source. It is important to run make manually after updating any 
+files in lib/ to update the versions in node/.
+
 ## Credits
 
 - The SVG badge generation was taken from the

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "slackin": "./bin/slackin"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "postinstall": "make"
   }
 }


### PR DESCRIPTION
The Makefile in the project was pretty sparse. This commit turns it into a working makefile, where each prerequisite .js file in lib/ has a corresponding target in node/. As a result, invoking make will automatically determine which updated source files need to be transpiled again and incrementally do so. Similarly, files in lib/assets/ are incrementally copied to node/assets/. There is also a clean target to remove the node/ directory.

After cleaning up the make, I updated package.json and Procfile in order to tweak the heroku build/deploy process. Before, Heroku created node_modules and packaged them along with the source into a slug. This slug was deployed to a dyno, which would then invoke make and finally run the server. With this change, make happens during the build, so the built files in node/ are part of the slug. This should improve dyno start times.

Finally, I added some documentation about make and babel to the Readme.