### PR TITLE
Add openshift support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -52,7 +52,7 @@ Read more about the [motivations and history](http://rauchg.com/slackin) behind 
   rhc alias-add slack.YOUR_DOMAIN.COM -a slackin
   ```
   
-  Then create CNAME record with your DNS host pointing `slack.YOUR_DOMAIN.com` to `slackin-YOUR_OPENSHIFT_NAMESPACE.rhcloud.com`
+  Then create CNAME record with your DNS host pointing `slack.YOUR_DOMAIN.COM` to `slackin-YOUR_OPENSHIFT_NAMESPACE.rhcloud.com`
 
 1. Deploy slackin to your app:
   
@@ -60,7 +60,7 @@ Read more about the [motivations and history](http://rauchg.com/slackin) behind 
   rhc app deploy https://github.com/balupton/slackin.git#feature-openshift -a slackin
   ```
 
-1. You should all be good now! Check the logs of your app using:
+1. You should be all good now! Check the logs of your app with:
   
   ``` shell
   rhc tail -a slackin

--- a/Readme.md
+++ b/Readme.md
@@ -19,9 +19,56 @@ Read more about the [motivations and history](http://rauchg.com/slackin) behind 
 
 ### Server
 
+
+#### Heroku
+
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/rauchg/slackin/tree/0.5.1)
 
-Or install it and launch it on your server:
+#### OpenShift
+
+1. Create your [OpenShift](https://openshift.redhat.com) Account
+
+1. Create a new OpenShift application for slackin:
+
+  ``` shell
+  rhc app create slackin https://raw.githubusercontent.com/kyrylkov/openshift-iojs/master/metadata/manifest.yml
+  ```
+
+1. Identify the following variable values:
+
+  - `SLACK_SUBDOMAIN`: Your Slack's subdomain (**this**.slack.com)",
+  - `SLACK_API_TOKEN`: A Slack API token (find it on https://api.slack.com/web)
+  - `SLACK_CHANNELS` (optional): Comma-separated list of single guest channels to invite them to (leave blank for a normal, all-channel invite). In order to make this work, you have to have a paid account. You'll only be able to invite as many people as your number of paying members times 5.
+  
+  And set them using:
+
+  ``` shell
+  rhc set-env -a slackin SLACK_API_TOKEN='' SLACK_SUBDOMAIN='' SLACK_CHANNELS=''
+  ```
+
+1. Add the domain alias for your app:
+
+  ``` shell
+  rhc alias-add slack.YOUR_DOMAIN.COM -a slackin
+  ```
+
+1. Deploy slackin to your app:
+  
+  ``` shell
+  rhc app deploy https://github.com/balupton/slackin.git#feature-openshift
+  ```
+
+1. You should all be good now! Check the logs of your app using:
+  
+  ``` shell
+  rhc tail -a slackin
+  ```
+
+
+#### Custom
+
+
+Install it and launch it on your server:
 
 ```bash
 $ npm install -g slackin

--- a/Readme.md
+++ b/Readme.md
@@ -57,7 +57,7 @@ Read more about the [motivations and history](http://rauchg.com/slackin) behind 
 1. Deploy slackin to your app:
   
   ``` shell
-  rhc app deploy https://github.com/balupton/slackin.git#feature-openshift -a slackin
+  rhc deploy-app --ref git@github.com:balupton/slackin.git#feature-openshift -a slackin
   ```
 
 1. You should be all good now! Check the logs of your app with:

--- a/Readme.md
+++ b/Readme.md
@@ -26,50 +26,7 @@ Read more about the [motivations and history](http://rauchg.com/slackin) behind 
 
 #### OpenShift
 
-1. Create your [OpenShift](https://openshift.redhat.com) account and [install their client tools](https://developers.openshift.com/en/managing-client-tools.html)
-
-1. Create a new OpenShift application for slackin:
-
-  ``` shell
-  rhc app-create slackin https://raw.githubusercontent.com/kyrylkov/openshift-iojs/master/metadata/manifest.yml
-  ```
-
-1. Identify the following variable values:
-
-  - `SLACK_SUBDOMAIN`: Your Slack's subdomain (the `this` part in `this.slack.com`),
-  - `SLACK_API_TOKEN`: A Slack API token (find it on https://api.slack.com/web)
-  - `SLACK_CHANNELS` (optional): Comma-separated list of single guest channels to invite them to (leave blank for a normal, all-channel invite). In order to make this work, you have to have a paid account. You'll only be able to invite as many people as your number of paying members times 5.
-  
-  And set them for the app using:
-
-  ``` shell
-  rhc env-set -a slackin SLACK_API_TOKEN="$SLACK_API_TOKEN" SLACK_SUBDOMAIN="$SLACK_SUBDOMAIN" SLACK_CHANNELS="$SLACK_CHANNELS"
-  ```
-
-1. If you'd like a custom domain, run:
-
-  ``` shell
-  rhc alias-add $SLACK_CUSTOM_DOMAIN -a slackin
-  ```
-  
-  Where `$SLACK_CUSTOM_DOMAIN` is something like `slack.bevry.me` where `bevry.me` is your domain name. Then create CNAME record with your DNS host pointing `slack.YOUR_DOMAIN.COM` to `slackin-YOUR_OPENSHIFT_NAMESPACE.rhcloud.com`
-
-1. Deploy slackin to your app:
-  
-  ``` shell
-  git clone https://github.com/balupton/slackin.git -b feature-openshift
-  cd slackin
-  git remote add openshift `rhc app-show slackin | grep Git | sed 's/^.*ssh/ssh/'`
-  git push openshift feature-openshift:master --force
-  cd ..
-  rm -Rf slackin
-  ```
-
-1. You should be all good now! Check the logs of your app with:
-  
-  ``` shell
-  rhc tail -a slackin
-  ```
+[Follow these instructions.](https://github.com/rauchg/slackin/wiki/OpenShift)
 
 
 #### Custom

--- a/Readme.md
+++ b/Readme.md
@@ -57,7 +57,7 @@ Read more about the [motivations and history](http://rauchg.com/slackin) behind 
 1. Deploy slackin to your app:
   
   ``` shell
-  git clone https://github.com/balupton/slackin.git
+  git clone https://github.com/balupton/slackin.git -b feature-openshift
   cd slackin
   git remote add openshift `rhc app-show slackin | grep Git | sed 's/^.*ssh/ssh/'`
   git push openshift feature-openshift:slackin --force

--- a/Readme.md
+++ b/Readme.md
@@ -40,17 +40,19 @@ Read more about the [motivations and history](http://rauchg.com/slackin) behind 
   - `SLACK_API_TOKEN`: A Slack API token (find it on https://api.slack.com/web)
   - `SLACK_CHANNELS` (optional): Comma-separated list of single guest channels to invite them to (leave blank for a normal, all-channel invite). In order to make this work, you have to have a paid account. You'll only be able to invite as many people as your number of paying members times 5.
   
-  And set them using:
+  And set them for the app using:
 
   ``` shell
   rhc set-env -a slackin SLACK_API_TOKEN='' SLACK_SUBDOMAIN='' SLACK_CHANNELS=''
   ```
 
-1. Add the domain alias for your app:
+1. If you'd like a custom domain, run:
 
   ``` shell
   rhc alias-add slack.YOUR_DOMAIN.COM -a slackin
   ```
+  
+  Then create CNAME record with your DNS host pointing `slack.YOUR_DOMAIN.com` to `slackin-YOUR_OPENSHIFT_NAMESPACE.rhcloud.com`
 
 1. Deploy slackin to your app:
   

--- a/Readme.md
+++ b/Readme.md
@@ -57,7 +57,7 @@ Read more about the [motivations and history](http://rauchg.com/slackin) behind 
 1. Deploy slackin to your app:
   
   ``` shell
-  rhc app deploy https://github.com/balupton/slackin.git#feature-openshift
+  rhc app deploy https://github.com/balupton/slackin.git#feature-openshift -a slackin
   ```
 
 1. You should all be good now! Check the logs of your app using:

--- a/Readme.md
+++ b/Readme.md
@@ -31,7 +31,7 @@ Read more about the [motivations and history](http://rauchg.com/slackin) behind 
 1. Create a new OpenShift application for slackin:
 
   ``` shell
-  rhc app create slackin https://raw.githubusercontent.com/kyrylkov/openshift-iojs/master/metadata/manifest.yml
+  rhc app-create slackin https://raw.githubusercontent.com/kyrylkov/openshift-iojs/master/metadata/manifest.yml
   ```
 
 1. Identify the following variable values:
@@ -43,16 +43,16 @@ Read more about the [motivations and history](http://rauchg.com/slackin) behind 
   And set them for the app using:
 
   ``` shell
-  rhc set-env -a slackin SLACK_API_TOKEN='' SLACK_SUBDOMAIN='' SLACK_CHANNELS=''
+  rhc env-set -a slackin SLACK_API_TOKEN="$SLACK_API_TOKEN" SLACK_SUBDOMAIN="$SLACK_SUBDOMAIN" SLACK_CHANNELS="$SLACK_CHANNELS"
   ```
 
 1. If you'd like a custom domain, run:
 
   ``` shell
-  rhc alias-add slack.YOUR_DOMAIN.COM -a slackin
+  rhc alias-add $SLACK_CUSTOM_DOMAIN -a slackin
   ```
   
-  Then create CNAME record with your DNS host pointing `slack.YOUR_DOMAIN.COM` to `slackin-YOUR_OPENSHIFT_NAMESPACE.rhcloud.com`
+  Where `$SLACK_CUSTOM_DOMAIN` is something like `slack.bevry.me` where `bevry.me` is your domain name. Then create CNAME record with your DNS host pointing `slack.YOUR_DOMAIN.COM` to `slackin-YOUR_OPENSHIFT_NAMESPACE.rhcloud.com`
 
 1. Deploy slackin to your app:
   

--- a/Readme.md
+++ b/Readme.md
@@ -36,7 +36,7 @@ Read more about the [motivations and history](http://rauchg.com/slackin) behind 
 
 1. Identify the following variable values:
 
-  - `SLACK_SUBDOMAIN`: Your Slack's subdomain (**this**.slack.com)",
+  - `SLACK_SUBDOMAIN`: Your Slack's subdomain (the `this` part in `this.slack.com`),
   - `SLACK_API_TOKEN`: A Slack API token (find it on https://api.slack.com/web)
   - `SLACK_CHANNELS` (optional): Comma-separated list of single guest channels to invite them to (leave blank for a normal, all-channel invite). In order to make this work, you have to have a paid account. You'll only be able to invite as many people as your number of paying members times 5.
   

--- a/Readme.md
+++ b/Readme.md
@@ -26,7 +26,7 @@ Read more about the [motivations and history](http://rauchg.com/slackin) behind 
 
 #### OpenShift
 
-1. Create your [OpenShift](https://openshift.redhat.com) Account
+1. Create your [OpenShift](https://openshift.redhat.com) account and [install their client tools](https://developers.openshift.com/en/managing-client-tools.html)
 
 1. Create a new OpenShift application for slackin:
 

--- a/Readme.md
+++ b/Readme.md
@@ -57,7 +57,12 @@ Read more about the [motivations and history](http://rauchg.com/slackin) behind 
 1. Deploy slackin to your app:
   
   ``` shell
-  rhc deploy-app --ref git@github.com:balupton/slackin.git#feature-openshift -a slackin
+  git clone https://github.com/balupton/slackin.git
+  cd slackin
+  git remote add openshift `rhc app-show slackin | grep Git | sed 's/^.*ssh/ssh/'`
+  git push openshift feature-openshift:slackin --force
+  cd ..
+  rm -Rf slackin
   ```
 
 1. You should be all good now! Check the logs of your app with:

--- a/bin/slackin
+++ b/bin/slackin
@@ -7,7 +7,8 @@ var slackin = require('../node');
 program
 .version(pkg.version)
 .usage('[options] <slack-subdomain> <api-token>')
-.option('-p, --port <port>', 'Port to listen on [$PORT or 3000]', process.env.PORT || 3000)
+.option('-p, --port <port>', 'Port to listen on [$PORT or 3000]', require('hostenv').PORT || 3000)
+.option('-h, --hostname <hostname>', 'Hostname to listen on [$HOSTNAME or 0.0.0.0]', require('hostenv').HOSTNAME || '0.0.0.0')
 .option('-c, --channels [<chan>]', 'One or more comma-separated channel names to allow single-channel guests [$SLACK_CHANNELS]', process.env.SLACK_CHANNELS)
 .option('-c, --channel <chan>', 'Single channel guest invite (deprecated) [$SLACK_CHANNEL]', process.env.SLACK_CHANNEL)
 .option('-i, --interval <int>', 'How frequently (ms) to poll Slack [$SLACK_INTERVAL or 1000]', process.env.SLACK_INTERVAL || 1000)
@@ -28,7 +29,8 @@ if (!program.channels && program.channel) {
 }
 
 var port = program.port;
-slackin(program).listen(port, function(err){
+var hostname = program.hostname;
+slackin(program).listen(port, hostname, function(err){
   if (err) throw err;
-  if (!program.silent) console.log('%s – listening on *:%d', new Date, port);
+  if (!program.silent) console.log('%s – listening on %s:%d', new Date, hostname, port);
 });

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "nock": "0.48.1",
     "supertest": "0.15.0"
   },
+  "engines": {
+    "node": ">=0.12.0"
+  },
   "main": "./node/index",
   "bin": {
     "slackin": "./bin/slackin"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "debug": "2.1.1",
     "email-regex": "1.0.0",
     "express": "4.11.0",
-    "hostenv": "^1.0.1",
+    "hostenv": "1.0.1",
     "opentype.js": "0.4.4",
     "socket.io": "1.3.5",
     "superagent": "0.21.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "scripts": {
     "test": "mocha",
     "postinstall": "make",
-    "start": "./bin/slackin"
+    "start": "npm install && ./bin/slackin"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "scripts": {
     "test": "mocha",
     "postinstall": "make",
-    "start": "npm install && ./bin/slackin"
+    "start": "npm install && ./bin/slackin $SLACK_SUBDOMAIN $SLACK_API_TOKEN"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "debug": "2.1.1",
     "email-regex": "1.0.0",
     "express": "4.11.0",
+    "hostenv": "^1.0.1",
     "opentype.js": "0.4.4",
     "socket.io": "1.3.5",
     "superagent": "0.21.0",
@@ -25,6 +26,7 @@
   },
   "scripts": {
     "test": "mocha",
-    "postinstall": "make"
+    "postinstall": "make",
+    "start": "./bin/slackin"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   "scripts": {
     "test": "mocha",
     "postinstall": "make",
-    "start": "npm install && ./bin/slackin $SLACK_SUBDOMAIN $SLACK_API_TOKEN"
+    "start": "./bin/slackin $SLACK_SUBDOMAIN $SLACK_API_TOKEN"
   }
 }


### PR DESCRIPTION
As Heroku now requires popular free dynos to be down for 6 hours a day, moving from Heroku to OpenShift is probably something people want to do. This pull request adds support for OpenShift.

Uses https://github.com/bevry/hostenv to fetch the correct PORT and HOSTNAME variables for many different servers (including openshift). OpenShift requires explicit hostname on `.listen`.

Once merged, `rhc app deploy https://github.com/balupton/slackin.git#feature-openshift` should be changed to `rhc app deploy https://github.com/raunchg/slackin.git#master`

To get started with OpenShift today (before this pull request is merged), you can browse the instructions here: https://github.com/balupton/slackin/tree/feature-openshift#openshift