### PR TITLE
For new signin link, use target=_top so iframes work

### DIFF
--- a/lib/splash.js
+++ b/lib/splash.js
@@ -34,7 +34,7 @@ export default function splash({ name, org, logo, active, total, channels, ifram
     ),
     !iframe && dom('p.signin',
       'or ',
-      dom(`a href=https://${org}.slack.com`, 'sign in'),
+      dom(`a href=https://${org}.slack.com target=_top`, 'sign in'),
       '.'
     ),
     !iframe && dom('footer',


### PR DESCRIPTION
Currently, no target set in the iframe can rain on some parades. This makes sure no rain happens, only _Slackshine_.

Couldn't resist..