### PR TITLE
Performance fixes

### DIFF
--- a/bin/slackin
+++ b/bin/slackin
@@ -11,7 +11,7 @@ program
 .option('-h, --hostname <hostname>', 'Hostname to listen on [$HOSTNAME or 0.0.0.0]', require('hostenv').HOSTNAME || '0.0.0.0')
 .option('-c, --channels [<chan>]', 'One or more comma-separated channel names to allow single-channel guests [$SLACK_CHANNELS]', process.env.SLACK_CHANNELS)
 .option('-c, --channel <chan>', 'Single channel guest invite (deprecated) [$SLACK_CHANNEL]', process.env.SLACK_CHANNEL)
-.option('-i, --interval <int>', 'How frequently (ms) to poll Slack [$SLACK_INTERVAL or 1000]', process.env.SLACK_INTERVAL || 1000)
+.option('-i, --interval <int>', 'How frequently (ms) to poll Slack [$SLACK_INTERVAL or 5000]', process.env.SLACK_INTERVAL || 5000)
 .option('-s, --silent', 'Do not print out warns or errors')
 .option('-c, --css <file>', 'Full URL to a custom CSS file to use on the main page')
 .parse(process.argv);

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -12,13 +12,36 @@ export default class SlackData extends EventEmitter {
     this.org = {};
     this.users = {};
     this.channelsByName = {};
+    this.init();
     this.fetch();
+  }
+
+  init(){
+    request
+    .get(`https://${this.host}.slack.com/api/channels.list`)
+    .query({ token: this.token })
+    .end((err, res) => {
+      (res.body.channels || []).forEach(channel => {
+          this.channelsByName[channel.name] = channel;
+        });
+    });
+
+    request
+    .get(`https://${this.host}.slack.com/api/team.info`)
+    .query({ token: this.token })
+    .end((err, res) => {
+      let team = res.body.team;
+      this.org.name = team.name;
+      if (!team.icon.image_default) {
+        this.org.logo = team.icon.image_132;
+      }
+    });
   }
 
   fetch(){
     request
-    .get(`https://${this.host}.slack.com/api/rtm.start`)
-    .query({ token: this.token })
+    .get(`https://${this.host}.slack.com/api/users.list`)
+    .query({ token: this.token, presence: 1 })
     .end((err, res) => {
       this.onres(err, res);
     });
@@ -42,13 +65,7 @@ export default class SlackData extends EventEmitter {
       return this.retry();
     }
 
-    // reset the list of channels
-    this.channelsByName = {};
-    (res.body.channels || []).forEach(channel => {
-      this.channelsByName[channel.name] = channel;
-    });
-
-    let users = res.body.users;
+    let users = res.body.members;
 
     if (!users) {
       let err = new Error(`Invalid Slack response: ${res.status}`);
@@ -78,12 +95,6 @@ export default class SlackData extends EventEmitter {
 
     this.users.total = total;
     this.users.active = active;
-
-    let team = res.body.team;
-    this.org.name = team.name;
-    if (!team.icon.image_default) {
-      this.org.logo = team.icon.image_132;
-    }
 
     if (!this.ready) {
       this.ready = true;


### PR DESCRIPTION
Hi :wave:. I work for Slack and I'd like to make some updates to this app to improve performance and reduce the load on Slack's servers.

1. Commit https://github.com/rauchg/slackin/commit/27cc41bf214d31c88b46eb60b36a970930e59218 was intended to increase the default polling interval, but this value was always being overriden by `bin/slackin` so I updated it to 5s there as well
2. The `rtm.start` API call is quite expensive and returns a lot more data than Slackin uses. However until recently it was the only way for you to get bulk user presence data. I added a new optional arg to the `users.list` API called `presence` which, if passed, will include the presence data there. I've updated the code to poll this instead of `rtm.start` which will be much faster and lighter on the servers. The other pieces of data Slackin pulls from `rtm.start` are the channel list and the team name. I added an `init` method to fetch those once using the appropriate APIs on startup (`channels.list` and `teams.info`), since they're unlikely to change. 

Happy to work with you further on changing this around to suit the coding style. 

**Testing Done**

Tested against my team. Ensured presence updated when I signed on as a user. Passed the channels argument and used console logs to print out the channel names to make sure those were still getting loaded properly.