### PR TITLE
Fix tests by adding missing mocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "mocha": "2.2.4",
-    "nock": "0.48.1",
+    "nock": "^2.17.0",
     "supertest": "0.15.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "mocha": "2.2.4",
-    "nock": "^2.17.0",
+    "nock": "2.17.0",
     "supertest": "0.15.0"
   },
   "engines": {

--- a/test/index.js
+++ b/test/index.js
@@ -4,18 +4,30 @@ import slackin from '../lib/index';
 
 describe('slackin', () => {
   describe('POST /invite', () => {
-    let mockNumUsers = (org) => {
-      nock(`https://${org}.slack.com`)
-        .get('/api/rtm.start?token=mytoken')
+    beforeEach(() => {
+      nock('https://myorg.slack.com')
+        .get('/api/users.list')
+        .query({token: 'mytoken', presence: '1'})
+        .query({token: 'mytoken'})
         .reply(200, {
-          channels: [{}],
-          team: {
-            name: 'myteam',
-            icon: {}
-          },
-          users: [{}]
+          ok: true,
+          members: [{}]
         });
-    };
+
+      nock('https://myorg.slack.com')
+        .get('/api/channels.list?token=mytoken')
+        .reply(200, {
+          ok: true,
+          channels: [{}]
+        });
+
+      nock('https://myorg.slack.com')
+        .get('/api/team.info?token=mytoken')
+        .reply(200, {
+          ok: true,
+          team: {icon: {}}
+        })
+    });
 
     it("returns success for a successful invite", (done) => {
       let opts = {
@@ -24,7 +36,6 @@ describe('slackin', () => {
       };
 
       // TODO simplify mocking
-      mockNumUsers(opts.org);
       nock(`https://${opts.org}.slack.com`)
         .post('/api/users.admin.invite')
         .reply(200, { ok: true });
@@ -46,7 +57,6 @@ describe('slackin', () => {
       };
 
       // TODO simplify mocking
-      mockNumUsers(opts.org);
       nock(`https://${opts.org}.slack.com`)
         .post('/api/users.admin.invite')
         .reply(200, {


### PR DESCRIPTION
The latest changes in v0.6.0 seemed to have caused the tests to fail, due to some missing Slack API mocks. This PR adds those mocks, and also upgrades nock to the latest version so that `.query()` can be used. Thanks for considering!