### PR TITLE
Make invite post a relative path

### DIFF
--- a/lib/assets/client.js
+++ b/lib/assets/client.js
@@ -33,7 +33,7 @@ body.addEventListener('submit', function(ev){
 
 function invite(channel, email, fn){
   request
-  .post('/invite')
+  .post('invite')
   .send({
     channel: channel,
     email: email


### PR DESCRIPTION
This is necessary to get invite POSTing working when you host slackin in a subpath.