### PR TITLE
Fix --path option parsing

### DIFF
--- a/bin/slackin
+++ b/bin/slackin
@@ -12,7 +12,7 @@ program
 .option('-c, --channels [<chan>]', 'One or more comma-separated channel names to allow single-channel guests [$SLACK_CHANNELS]', process.env.SLACK_CHANNELS)
 .option('-c, --channel <chan>', 'Single channel guest invite (deprecated) [$SLACK_CHANNEL]', process.env.SLACK_CHANNEL)
 .option('-i, --interval <int>', 'How frequently (ms) to poll Slack [$SLACK_INTERVAL or 5000]', process.env.SLACK_INTERVAL || 5000)
-.option('-P, --path', 'Path to serve slackin under', '/')
+.option('-P, --path <path>', 'Path to serve slackin under', '/')
 .option('-s, --silent', 'Do not print out warns or errors')
 .option('-C, --coc <coc>', 'Full URL to a CoC that needs to be agreed to')
 .option('-c, --css <file>', 'Full URL to a custom CSS file to use on the main page')


### PR DESCRIPTION
No parameter was specified for the option which made it be broken. This
fixes `slackin --path "/slack/" org token`.