### PR TITLE
Set maxListeners to 0 or user defined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,8 +26,7 @@ export default function slackin({
   coc,
   path='/',
   channels,
-  silent = false, // jshint ignore:line,
-  maxListeners = 0
+  silent = false // jshint ignore:line,
 }){
   // must haves
   if (!token) throw new Error('Must provide a `token`.');
@@ -50,7 +49,7 @@ export default function slackin({
   // fetch data
   let slack = new Slack({ token, interval, org });
 
-  slack.setMaxListeners(maxListeners);
+  slack.setMaxListeners(Infinity);
 
   // capture stats
   log(slack, silent);

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,8 @@ export default function slackin({
   coc,
   path='/',
   channels,
-  silent = false // jshint ignore:line
+  silent = false, // jshint ignore:line,
+  maxListeners = 0
 }){
   // must haves
   if (!token) throw new Error('Must provide a `token`.');
@@ -48,6 +49,8 @@ export default function slackin({
 
   // fetch data
   let slack = new Slack({ token, interval, org });
+
+  slack.setMaxListeners(maxListeners);
 
   // capture stats
   log(slack, silent);


### PR DESCRIPTION
This will get rid of the following errors being thrown by the slack object.

(node) warning: possible EventEmitter memory leak detected. 11 change listeners
added. Use emitter.setMaxListeners() to increase limit.