### PR TITLE
Add success message for already signed up users

### DIFF
--- a/lib/assets/client.js
+++ b/lib/assets/client.js
@@ -19,14 +19,14 @@ body.addEventListener('submit', function(ev){
   button.className = '';
   button.innerHTML = 'Please Wait';
   var channel = select ? select.value : null;
-  invite(channel, coc && coc.checked ? 1 : 0, input.value, function(err){
+  invite(channel, coc && coc.checked ? 1 : 0, input.value, function(err, msg){
     if (err) {
       button.removeAttribute('disabled');
       button.className = 'error';
       button.innerHTML = err.message;
     } else {
       button.className = 'success';
-      button.innerHTML = 'WOOT. Check your email!';
+      button.innerHTML = msg;
     }
   });
 });
@@ -51,7 +51,7 @@ function invite(channel, coc, email, fn){
       var err = new Error(res.body.msg || 'Server error');
       return fn(err);
     } else {
-      fn(null);
+      fn(null, res.body.msg);
     }
   });
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -123,7 +123,7 @@ export default function slackin({
 
     invite({ token, org, email, channel: chanId }, err => {
       if (err) {
-        if (err.message === `Already invited. Sending you to https://${org}.slack.com...`) {
+        if (err.message === `Sending you to Slack...`) {
           return res
           .status(303)
           .json({ msg: err.message, redirectUrl: `https://${org}.slack.com` });

--- a/lib/index.js
+++ b/lib/index.js
@@ -123,7 +123,7 @@ export default function slackin({
 
     invite({ token, org, email, channel: chanId }, err => {
       if (err) {
-        if (err.redirectUrl) {
+        if (err.message === `Already invited. Sending you to https://${org}.slack.com...`) {
           return res
           .status(303)
           .json({ msg: err.message, redirectUrl: `https://${org}.slack.com` });
@@ -136,7 +136,7 @@ export default function slackin({
 
       res
       .status(200)
-      .json({ msg: 'success' });
+      .json({ msg: 'WOOT. Check your email!' });
     });
   });
 

--- a/lib/slack-invite.js
+++ b/lib/slack-invite.js
@@ -32,7 +32,7 @@ export default function invite({ org, token, email, channel }, fn){
       } else if (providedError === 'already_invited') {
         fn(new Error('You have already been invited to slack. Check for an email from feedback@slack.com.'));
       } else if (providedError === 'already_in_team') {
-        fn(new Error(`Already invited. Sending you to https://${org}.slack.com...`));
+        fn(new Error(`Sending you to Slack...`));
       } else {
         fn(new Error(providedError));
       }


### PR DESCRIPTION
Would love to get a second set of eyes on this for review.

This adds onto #126, showing a new success message right before users get redirected to Slack.