### PR TITLE
Fix mocha opts

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -46,7 +46,7 @@ describe('slackin', () => {
         .post('/invite')
         .send({ email: 'foo@example.com' })
         .expect('Content-Type', /json/)
-        .expect(200, { msg: 'success' })
+        .expect(200, { msg: 'WOOT. Check your email!' })
         .end(done);
     });
 

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,2 @@
---compilers js:babel/register
+--compilers js:babel-register
 --require ./test/setup


### PR DESCRIPTION
I'm relatively unacquainted with nodejs, but it appears that the module name for babel-register changed. Without my change, I see:

```
> slackin@0.8.2 test /home/jesse/workspace/slackin
> mocha

module.js:341
    throw err;
    ^

Error: Cannot find module 'babel/register'
    at Function.Module._resolveFilename (module.js:339:15)
    at Function.Module._load (module.js:290:25)
    at Module.require (module.js:367:17)
    at require (internal/module.js:16:19)
    at /home/jesse/workspace/slackin/node_modules/mocha/bin/_mocha:300:3
    at Array.forEach (native)
    at Object.<anonymous> (/home/jesse/workspace/slackin/node_modules/mocha/bin/_mocha:294:19)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Function.Module.runMain (module.js:447:10)
    at startup (node.js:140:18)
    at node.js:1001:3
npm ERR! Test failed.  See above for more details.
```

Also fixed a broken test that I saw once getting the tests working.