### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - stable


### PR DESCRIPTION
Looks like the defaults on Travis do the Right Thing to run the tests.
I started with just nodejs stable, but I'm curious if you think we should add
more versions
(https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Provided-Node.js-Versions).

Ref #149