### PR TITLE
Fix form when SLACK_CHANNELS contains only one entry

### DIFF
--- a/lib/assets/client.js
+++ b/lib/assets/client.js
@@ -4,9 +4,10 @@ var body = document.body;
 var request = superagent;
 
 // elements
-var select = body.querySelector('select');
-var input = body.querySelector('input');
-var coc = body.querySelector('input[name=coc]');
+var form = body.querySelector('form#invite');
+var channel = form.elements['channel'];
+var email = form.elements['email'];
+var coc = form.elements['coc'];
 var button = body.querySelector('button');
 
 // remove loading state
@@ -18,8 +19,7 @@ body.addEventListener('submit', function(ev){
   button.disabled = true;
   button.className = '';
   button.innerHTML = 'Please Wait';
-  var channel = select ? select.value : null;
-  invite(channel, coc && coc.checked ? 1 : 0, input.value, function(err, msg){
+  invite(channel.value, coc && coc.checked ? 1 : 0, email.value, function(err, msg){
     if (err) {
       button.removeAttribute('disabled');
       button.className = 'error';

--- a/lib/splash.js
+++ b/lib/splash.js
@@ -21,14 +21,19 @@ export default function splash({ path, name, org, coc, logo, active, total, chan
         ]
         : [dom('b.total', total), ' users are registered so far.']
     ),
-    dom('form',
-      // channel selection when there are multiple
-      channels && channels.length > 1 && dom('select.form-item name=channel',
-        channels.map(channel => {
-          return dom('option', { value: channel, text: channel });
-        })
+    dom('form id=invite',
+      channels && (
+        channels.length > 1
+          // channel selection when there are multiple
+          ? dom('select.form-item name=channel',
+              channels.map(channel => {
+                return dom('option', { value: channel, text: channel });
+              })
+            )
+          // otherwise a fixed channel
+          : dom('input type=hidden name=channel', { value: channels[0] })
       ),
-      dom('input.form-item type=email placeholder=you@yourdomain.com '
+      dom('input.form-item type=email name=email placeholder=you@yourdomain.com '
         + (!iframe ? 'autofocus' : '')),
       coc && dom('.coc',
         dom('label',


### PR DESCRIPTION
e35a05b9ca4b3754f814246542c87785af967650 introduced a problem -- the form sends `channel=null` when `SLACK_CHANNELS` contains only one entry, but [the relevant form handler](https://github.com/rauchg/slackin/blob/e3d31942c1c4c070b31f005e54addd46a644fac9/lib/index.js#L91) doesn't seem to cope with this scenario.

I figured the easiest way to fix this was to inject an `<input type="hidden">` in the single-channel case. This seems to work nicely, after a small tweak to the client-side form handler.

Fixes #77.