### PR TITLE
Add "or sign in" link to iframe too

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -152,7 +152,7 @@ export default function slackin({
     let { name } = slack.org;
     let { active, total } = slack.users;
     if (!name) return res.send(404);
-    let dom = splash({ coc, path, name, channels, active, total, iframe: true });
+    let dom = splash({ coc, path, name, org, channels, active, total, iframe: true });
     res.type('html');
     res.send(dom.toHTML());
   });

--- a/lib/splash.js
+++ b/lib/splash.js
@@ -40,7 +40,7 @@ export default function splash({ path, name, org, coc, logo, active, total, chan
       ),
       dom('button.loading', 'Get my Invite')
     ),
-    !iframe && dom('p.signin',
+    dom('p.signin',
       'or ',
       dom(`a href=https://${org}.slack.com target=_top`, 'sign in'),
       '.'
@@ -297,22 +297,20 @@ function style({ logo, active, iframe } = {}){
     });
   }
 
-  if (!iframe) {
-    css.add('p.signin', {
-      'padding': '10px 0 10px',
-      'font-size': '11px'
-    });
+  css.add('p.signin', {
+    'padding': '10px 0 10px',
+    'font-size': '11px'
+  });
 
-    css.add('p.signin a', {
-      'color': pink,
-      'text-decoration': 'none'
-    });
+  css.add('p.signin a', {
+    'color': pink,
+    'text-decoration': 'none'
+  });
 
-    css.add('p.signin a:hover', {
-      'background-color': '#E01563',
-      color: '#fff'
-    });
-  }
+  css.add('p.signin a:hover', {
+    'background-color': '#E01563',
+    color: '#fff'
+  });
 
   if (!iframe) {
     css.add('footer', {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/225809/13372862/e4f23c2c-dd0a-11e5-8a4c-b4cfda47d2e3.png)

Why was it excluded in #80? With the button that opens the iframe
dialog, there's no link to the landing page, which means with the button
there's no link at all to the actual Slack channel.