### PR TITLE
Fix ?large to also control size of dialog

### DIFF
--- a/lib/assets/badge.js
+++ b/lib/assets/badge.js
@@ -28,14 +28,16 @@
     }
   }
 
+  var LARGE; // boolean for large/small mode, from query param
+
   // replace the script tag with an iframe
   function replace(script){
     var parent = script.parentNode;
     if (!parent) return;
 
-    var large = /\?large/.test(script.src);
+    LARGE = /\?large/.test(script.src);
     var iframe = document.createElement('iframe');
-    var iframePath = '/iframe' + (large ? '?large' : '');
+    var iframePath = '/iframe' + (LARGE ? '?large' : '');
     iframe.src = script.src.replace(/\/slackin\.js.*/, iframePath);
     iframe.style.borderWidth = 0;
     iframe.className = '__slackin';
@@ -44,10 +46,10 @@
     // once we have the knowledge of the actual
     // numbers of users, based on a user count
     // of 3 digits by 3 digits
-    iframe.style.width = (large ? 190 : 140) + 'px';
+    iframe.style.width = (LARGE ? 190 : 140) + 'px';
 
     // height depends on target size
-    iframe.style.height = (large ? 30 : 20) + 'px';
+    iframe.style.height = (LARGE ? 30 : 20) + 'px';
 
     // hidden by default to avoid flicker
     iframe.style.visibility = 'hidden';
@@ -90,10 +92,18 @@
     if (showing) return;
     showing = true;
 
+    if (LARGE) {
+      unitSize = '14px';
+      arrowHeight = 13;
+    } else {
+      unitSize = '10px';
+      arrowHeight = 9;
+    }
+
     // container div
     var div = document.createElement('div');
     div.className = '__slackin';
-    div.style.fontSize = '10px';
+    div.style.fontSize = unitSize;
     div.style.border = '.1em solid #D6D6D6';
     div.style.padding = '0';
     div.style.margin = '0';
@@ -114,7 +124,7 @@
     ni.style.width = '25em';
     ni.style.height = '15.5em';
     ni.style.borderWidth = 0;
-    ni.src = iframe.src.replace(/\?.*/, '') + '/dialog';
+    ni.src = iframe.src.replace('iframe', 'iframe/dialog');
     ni.onload = function(){
       window.addEventListener('scroll', dposition);
       window.addEventListener('resize', dposition);
@@ -139,7 +149,7 @@
     a2.style.borderColor = 'rgba(250, 250, 250, 0)';
 
     a1.style.borderWidth = '.7em';
-    a1.style.marginLeft = '-.7em';
+    a1.style.marginLeft = '-.65em';
     a2.style.borderWidth = '.6em';
     a2.style.marginLeft = '-.6em';
 
@@ -159,7 +169,7 @@
 
       var divPos = div.getBoundingClientRect();
       var iframePos = iframe.getBoundingClientRect();
-      var divHeight = divPos.height + 9; // arrow height
+      var divHeight = divPos.height + arrowHeight;
 
       var st = document.body.scrollTop;
       var sl = document.body.scrollLeft;
@@ -178,7 +188,7 @@
         a1.style.borderTopColor = '#d6d6d6';
         a2.style.borderTopColor = '#fafafa';
       } else {
-        div.style.top = (iframeTop + iframePos.height + 9) + 'px';
+        div.style.top = (iframeTop + iframePos.height + arrowHeight) + 'px';
         a1.style.bottom = a2.style.bottom = '100%';
 
         a1.style.borderTopColor = 'rgba(214, 214, 214, 0)';

--- a/lib/assets/badge.js
+++ b/lib/assets/badge.js
@@ -93,25 +93,26 @@
     // container div
     var div = document.createElement('div');
     div.className = '__slackin';
-    div.style.border = '1px solid #D6D6D6';
+    div.style.fontSize = '10px';
+    div.style.border = '.1em solid #D6D6D6';
     div.style.padding = '0';
     div.style.margin = '0';
     div.style.lineHeight = '0';
     div.style.backgroundColor = '#FAFAFA';
-    div.style.width = '250px';
-    div.style.height = '155px';
+    div.style.width = '25em';
+    div.style.height = '15.5em';
     div.style.position = 'absolute';
     div.style.left = '-10000px';
     div.style.top = '-10000px';
-    div.style.borderRadius = '4px';
-    div.style.padding = '4px';
+    div.style.borderRadius = '.4em';
+    div.style.padding = '.4em';
     div.style.boxSizing = 'content-box';
 
     // new iframe
     var ni = document.createElement('iframe');
     ni.className = '__slackin';
-    ni.style.width = '250px';
-    ni.style.height = '155px';
+    ni.style.width = '25em';
+    ni.style.height = '15.5em';
     ni.style.borderWidth = 0;
     ni.src = iframe.src.replace(/\?.*/, '') + '/dialog';
     ni.onload = function(){
@@ -137,10 +138,10 @@
     a1.style.borderColor = 'rgba(214, 214, 214, 0)';
     a2.style.borderColor = 'rgba(250, 250, 250, 0)';
 
-    a1.style.borderWidth = '7px';
-    a1.style.marginLeft = '-7px';
-    a2.style.borderWidth = '6px';
-    a2.style.marginLeft = '-6px';
+    a1.style.borderWidth = '.7em';
+    a1.style.marginLeft = '-.7em';
+    a2.style.borderWidth = '.6em';
+    a2.style.marginLeft = '-.6em';
 
     // append
     div.appendChild(a1);

--- a/lib/index.js
+++ b/lib/index.js
@@ -149,10 +149,11 @@ export default function slackin({
   });
 
   app.get('/iframe/dialog', (req, res) => {
+    let large = 'large' in req.query;
     let { name } = slack.org;
     let { active, total } = slack.users;
     if (!name) return res.send(404);
-    let dom = splash({ coc, path, name, channels, active, total, iframe: true });
+    let dom = splash({ coc, path, name, channels, active, total, large, iframe: true });
     res.type('html');
     res.send(dom.toHTML());
   });

--- a/lib/splash.js
+++ b/lib/splash.js
@@ -1,7 +1,7 @@
 
 import dom from 'vd';
 
-export default function splash({ path, name, org, coc, logo, active, total, channels, iframe }){
+export default function splash({ path, name, org, coc, logo, active, total, channels, large, iframe }){
   let div = dom('.splash',
     !iframe && dom('.logos',
       logo && dom('.logo.org'),
@@ -49,7 +49,7 @@ export default function splash({ path, name, org, coc, logo, active, total, chan
       'powered by ',
       dom('a href=http://rauchg.com/slackin target=_blank', 'slackin')
     ),
-    style({ logo, active, iframe }),
+    style({ logo, active, large, iframe }),
     // xxx: single build
     dom('script', `
       data = {};
@@ -64,9 +64,9 @@ export default function splash({ path, name, org, coc, logo, active, total, chan
 
 const pink = '#E01563';
 
-function style({ logo, active, iframe } = {}){
+function style({ logo, active, large, iframe } = {}){
   var css = dom.style();
-  css.add('html', { 'font-size': '10px' });
+  css.add('html', { 'font-size': large ? '14px' : '10px' });
 
   css.add('.splash', {
     'width': iframe ? '25rem' : '30rem',

--- a/lib/splash.js
+++ b/lib/splash.js
@@ -66,10 +66,11 @@ const pink = '#E01563';
 
 function style({ logo, active, iframe } = {}){
   var css = dom.style();
+  css.add('html', { 'font-size': '10px' });
 
   css.add('.splash', {
-    'width': iframe ? '250px' : '300px',
-    'margin': iframe ? '0' : '200px auto',
+    'width': iframe ? '25rem' : '30rem',
+    'margin': iframe ? '0' : '20rem auto',
     'text-align': 'center',
     'font-family': '"Helvetica Neue", Helvetica, Arial'
   });
@@ -84,31 +85,31 @@ function style({ logo, active, iframe } = {}){
 
     css.add('.splash', {
       'box-sizing': 'border-box',
-      'padding': '10px'
+      'padding': '1rem'
     });
   }
 
   if (!iframe) {
     css
-    .media('(max-width: 500px)')
+    .media('(max-width: 50rem)')
     .add('.splash', {
-      'margin-top': '100px'
+      'margin-top': '10rem'
     });
   }
 
   css.add('.head', {
-    'margin-bottom': '40px'
+    'margin-bottom': '4rem'
   });
 
   css.add('.logos', {
     'position': 'relative',
-    'margin-bottom': '40px'
+    'margin-bottom': '4rem'
   });
 
   if (!iframe) {
     css.add('.logo', {
-      'width': '48px',
-      'height': '48px',
+      'width': '4.8rem',
+      'height': '4.8rem',
       'display': 'inline-block',
       'background-size': 'cover'
     });
@@ -118,43 +119,45 @@ function style({ logo, active, iframe } = {}){
     });
 
     if (logo) {
-      let pw = 10; // '+' width
-      let lp = 30; // logos separation
+      let pw = 1; // '+' width in rem
+      let lp = 3; // logos separation in rem
 
       css.add('.logo.org::after', {
         'position': 'absolute',
         'display': 'block',
         'content': '"+"',
-        'top': '15px',
+        'top': '1.5rem',
         'left': '0',
-        'width': '300px',
+        'width': '30rem',
         'text-align': 'center',
         'color': '#D6D6D6',
-        'font': '15px Helvetica Neue'
+        'font-size': '1.5rem', // can't use rem in font shorthand IE9-10
+              // http://codersblock.com/blog/font-shorthand-bug-in-ie10/
+        'font-family': 'Helvetica Neue'
       });
 
       css.add('.logo.org', {
         'background-image': `url(${logo})`,
-        'margin-right': `${lp + pw + lp}px`
+        'margin-right': `${lp + pw + lp}rem`
       });
     }
   }
 
   css.add('.coc', {
-    'font-size': '12px',
-    padding: '15px 0 5px',
+    'font-size': '1.2rem',
+    padding: '1.5rem 0 .5rem',
     color: '#666'
   });
 
   if (iframe) {
     css.add('.coc', {
-      'font-size': '11px',
-      'padding-top': '10px'
+      'font-size': '1.1rem',
+      'padding-top': '1rem'
     });
 
     css.add('.coc input', {
       position: 'relative',
-      top: '-2px'
+      top: '-.2rem'
     });
   }
 
@@ -167,14 +170,14 @@ function style({ logo, active, iframe } = {}){
     '-webkit-appearance': 'none',
     border: 'none',
     'vertical-align': 'middle',
-    margin: '0 5px 0 0',
+    margin: '0 .5rem 0 0',
   });
 
   css.add('.coc input::after', {
     content: '""',
     display: 'inline-block',
-    width: '15px',
-    height: '15px',
+    width: '1.5rem',
+    height: '1.5rem',
     'vertical-align': 'middle',
     background: 'url(/assets/checkbox.svg)',
     cursor: 'pointer'
@@ -195,13 +198,13 @@ function style({ logo, active, iframe } = {}){
   });
 
   css.add('p', {
-    'font-size': iframe ? '12px' : '15px',
-    'margin': iframe ? '0 0 5px' : '5px 0'
+    'font-size': iframe ? '1.2rem' : '1.5rem',
+    'margin': iframe ? '0 0 .5rem' : '.5rem 0'
   });
 
   if (iframe) {
     css.add('p.status', {
-      'font-size': '11px'
+      'font-size': '1.1rem'
     });
   }
 
@@ -210,14 +213,14 @@ function style({ logo, active, iframe } = {}){
   });
 
   css.add('button, .form-item', {
-    'font-size': '12px',
-    'margin-top': iframe ? '5px' : '10px',
+    'font-size': '1.2rem',
+    'margin-top': iframe ? '.5rem' : '1rem',
     'vertical-align': 'middle',
     'display': 'block',
     'text-align': 'center',
     'box-sizing': 'border-box',
     'width': '100%',
-    'padding': '9px'
+    'padding': '.9rem'
   });
 
   css.add('button', {
@@ -267,21 +270,21 @@ function style({ logo, active, iframe } = {}){
   });
 
   css.add('form', {
-    'margin-top': iframe ? '10px' : '20px',
+    'margin-top': iframe ? '1rem' : '2rem',
     'margin-bottom': '0'
   });
 
   css.add('input', {
     'color': '#9B9B9B',
-    'border': '1px solid #D6D6D6'
+    'border': '.1rem solid #D6D6D6'
   });
 
   if (iframe) {
     css.add('button, .form-item', {
-      'height': '28px',
-      'line-height': '28px',
+      'height': '2.8rem',
+      'line-height': '2.8rem',
       'padding': 0,
-      'font-size': '11px'
+      'font-size': '1.1rem'
     });
   }
 
@@ -299,8 +302,8 @@ function style({ logo, active, iframe } = {}){
 
   if (!iframe) {
     css.add('p.signin', {
-      'padding': '10px 0 10px',
-      'font-size': '11px'
+      'padding': '1rem 0 1rem',
+      'font-size': '1.1rem'
     });
 
     css.add('p.signin a', {
@@ -317,16 +320,16 @@ function style({ logo, active, iframe } = {}){
   if (!iframe) {
     css.add('footer', {
       'color': '#D6D6D6',
-      'font-size': '11px',
-      'margin': '200px auto 0',
-      'width': '300px',
+      'font-size': '1.1rem',
+      'margin': '20rem auto 0',
+      'width': '30rem',
       'text-align': 'center',
     });
 
     css.add('footer a', {
       'color': '#9B9B9B',
       'text-decoration': 'none',
-      'border-bottom': '1px solid #9B9B9B'
+      'border-bottom': '.1rem solid #9B9B9B'
     });
 
     css.add('footer a:hover', {


### PR DESCRIPTION
Passed along from `?large` to control the badge size, they now also
control the iframe and dialog size because after all, if you're on a
page with larger `font-size` that demands a larger badge, the small dialog
with small text is gonna look out of place:
![screenshot of small dialog](https://git.io/v2Xy4)

The large badge is about 1.5x the size of the small badge (30px to 20px;
the other ratios aren't as exact), but I found that making the large
dialog 1.4x the size of the small dialog looked better than 1.5x
(that is, bumping the `em`/`rem` unit font size from 10px to 14px rather
than 15px), I think because at 1.5x the text in the dialog becomes bigger
than the text in the badge:

font-size: 14px
![screenshot of 1.4x](https://git.io/v2XyJ)
vs
font-size: 15px
![screenshot of 1.5x](https://git.io/v2XDh)

--

See also https://github.com/rauchg/slackin/commit/6108430ed1698f4a0ea7d8bd966df3313582d667 for discussion of the `em`/`rem` technique