### PR TITLE
fix(redirects): use window.top when doing redirects on the client-side

### DIFF
--- a/lib/assets/client.js
+++ b/lib/assets/client.js
@@ -44,7 +44,7 @@ function invite(channel, coc, email, fn){
     if (res.body.redirectUrl) {
       var err = new Error(res.body.msg || 'Server error');
       window.setTimeout(function() {
-        location.href = res.body.redirectUrl;
+        top.location.href = res.body.redirectUrl;
       }, 1500);
     }
     if (res.error) {


### PR DESCRIPTION
when the widget is used inside an iframe, `location.href` is not enough to trigger a redirect. `top.location` *(and alias of `window.top.location`)* will ensure the redirect is correctly triggered.