### PR TITLE
Fix postMessage({}, '*') causes slackin to throw

### DIFF
--- a/lib/assets/badge.js
+++ b/lib/assets/badge.js
@@ -66,6 +66,8 @@
     var id = Math.random() * (1 << 24) | 0;
     iframe.contentWindow.postMessage('slackin:' + id, '*');
     window.addEventListener('message', function(e){
+      if (typeof e.data !== 'string') return;
+
       // show dialog upon click
       if ('slackin-click:' + id  == e.data) {
         showDialog(iframe);

--- a/lib/assets/badge.js
+++ b/lib/assets/badge.js
@@ -69,13 +69,13 @@
       if (typeof e.data !== 'string') return;
 
       // show dialog upon click
-      if ('slackin-click:' + id  == e.data) {
+      if ('slackin-click:' + id  === e.data) {
         showDialog(iframe);
       }
 
       // update width
       var wp = 'slackin-width:' + id + ':';
-      if (wp == e.data.substr(0, wp.length)) {
+      if (wp === e.data.substr(0, wp.length)) {
         var width = e.data.substr(wp.length);
         iframe.style.width = width + 'px';
 

--- a/lib/assets/iframe.js
+++ b/lib/assets/iframe.js
@@ -21,7 +21,7 @@
       document.body.addEventListener('click', function(ev){
         var el = ev.target;
         while (el && 'A' != el.nodeName) el = el.parentNode;
-        if (el && '_blank' == el.target) {
+        if (el && '_blank' === el.target) {
           ev.preventDefault();
           parent.postMessage('slackin-click:' + id, '*');
         }

--- a/lib/assets/superagent.js
+++ b/lib/assets/superagent.js
@@ -102,7 +102,7 @@ require.normalize = function(curr, path) {
   path = path.split('/');
 
   for (var i = 0; i < path.length; ++i) {
-    if ('..' == path[i]) {
+    if ('..' === path[i]) {
       curr.pop();
     } else if ('.' != path[i] && '' != path[i]) {
       segs.push(path[i]);
@@ -177,8 +177,8 @@ require.relative = function(parent) {
 
   localRequire.resolve = function(path) {
     var c = path.charAt(0);
-    if ('/' == c) return path.slice(1);
-    if ('.' == c) return require.normalize(p, path);
+    if ('/' === c) return path.slice(1);
+    if ('.' === c) return require.normalize(p, path);
 
     // resolve deps by returning
     // the dep in the nearest "deps"
@@ -291,7 +291,7 @@ Emitter.prototype.removeEventListener = function(event, fn){
   this._callbacks = this._callbacks || {};
 
   // all
-  if (0 == arguments.length) {
+  if (0 === arguments.length) {
     this._callbacks = {};
     return this;
   }
@@ -301,7 +301,7 @@ Emitter.prototype.removeEventListener = function(event, fn){
   if (!callbacks) return this;
 
   // remove all handlers
-  if (1 == arguments.length) {
+  if (1 === arguments.length) {
     delete this._callbacks[event];
     return this;
   }
@@ -382,7 +382,7 @@ require.register("component-reduce/index.js", function(exports, require, module)
 module.exports = function(arr, fn, initial){  
   var idx = 0;
   var len = arr.length;
-  var curr = arguments.length == 3
+  var curr = arguments.length === 3
     ? initial
     : arr[idx++];
 
@@ -405,7 +405,7 @@ var reduce = require('reduce');
  * Root reference for iframes.
  */
 
-var root = 'undefined' == typeof window
+var root = 'undefined' === typeof window
   ? this
   : window;
 
@@ -786,22 +786,22 @@ Response.prototype.setStatusProperties = function(status){
   this.statusType = type;
 
   // basics
-  this.info = 1 == type;
-  this.ok = 2 == type;
-  this.clientError = 4 == type;
-  this.serverError = 5 == type;
-  this.error = (4 == type || 5 == type)
+  this.info = 1 === type;
+  this.ok = 2 === type;
+  this.clientError = 4 === type;
+  this.serverError = 5 === type;
+  this.error = (4 === type || 5 === type)
     ? this.toError()
     : false;
 
   // sugar
-  this.accepted = 202 == status;
-  this.noContent = 204 == status || 1223 == status;
-  this.badRequest = 400 == status;
-  this.unauthorized = 401 == status;
-  this.notAcceptable = 406 == status;
-  this.notFound = 404 == status;
-  this.forbidden = 403 == status;
+  this.accepted = 202 === status;
+  this.noContent = 204 === status || 1223 === status;
+  this.badRequest = 400 === status;
+  this.unauthorized = 401 === status;
+  this.notAcceptable = 406 === status;
+  this.notFound = 404 === status;
+  this.forbidden = 403 === status;
 };
 
 /**
@@ -1176,10 +1176,10 @@ Request.prototype.send = function(data){
     for (var key in data) {
       this._data[key] = data[key];
     }
-  } else if ('string' == typeof data) {
+  } else if ('string' === typeof data) {
     if (!type) this.type('form');
     type = this.getHeader('Content-Type');
-    if ('application/x-www-form-urlencoded' == type) {
+    if ('application/x-www-form-urlencoded' === type) {
       this._data = this._data
         ? this._data + '&' + data
         : data;
@@ -1207,7 +1207,7 @@ Request.prototype.send = function(data){
 Request.prototype.callback = function(err, res){
   var fn = this._callback;
   this.clearTimeout();
-  if (2 == fn.length) return fn(err, res);
+  if (2 === fn.length) return fn(err, res);
   if (err) return this.emit('error', err);
   fn(res);
 };
@@ -1275,7 +1275,7 @@ Request.prototype.end = function(fn){
   // state change
   xhr.onreadystatechange = function(){
     if (4 != xhr.readyState) return;
-    if (0 == xhr.status) {
+    if (0 === xhr.status) {
       if (self.aborted) return self.timeoutError();
       return self.crossDomainError();
     }
@@ -1353,12 +1353,12 @@ request.Request = Request;
 
 function request(method, url) {
   // callback
-  if ('function' == typeof url) {
+  if ('function' === typeof url) {
     return new Request('GET', method).end(url);
   }
 
   // url first
-  if (1 == arguments.length) {
+  if (1 === arguments.length) {
     return new Request('GET', method);
   }
 
@@ -1377,7 +1377,7 @@ function request(method, url) {
 
 request.get = function(url, data, fn){
   var req = request('GET', url);
-  if ('function' == typeof data) fn = data, data = null;
+  if ('function' === typeof data) fn = data, data = null;
   if (data) req.query(data);
   if (fn) req.end(fn);
   return req;
@@ -1395,7 +1395,7 @@ request.get = function(url, data, fn){
 
 request.head = function(url, data, fn){
   var req = request('HEAD', url);
-  if ('function' == typeof data) fn = data, data = null;
+  if ('function' === typeof data) fn = data, data = null;
   if (data) req.send(data);
   if (fn) req.end(fn);
   return req;
@@ -1428,7 +1428,7 @@ request.del = function(url, fn){
 
 request.patch = function(url, data, fn){
   var req = request('PATCH', url);
-  if ('function' == typeof data) fn = data, data = null;
+  if ('function' === typeof data) fn = data, data = null;
   if (data) req.send(data);
   if (fn) req.end(fn);
   return req;
@@ -1446,7 +1446,7 @@ request.patch = function(url, data, fn){
 
 request.post = function(url, data, fn){
   var req = request('POST', url);
-  if ('function' == typeof data) fn = data, data = null;
+  if ('function' === typeof data) fn = data, data = null;
   if (data) req.send(data);
   if (fn) req.end(fn);
   return req;
@@ -1464,7 +1464,7 @@ request.post = function(url, data, fn){
 
 request.put = function(url, data, fn){
   var req = request('PUT', url);
-  if ('function' == typeof data) fn = data, data = null;
+  if ('function' === typeof data) fn = data, data = null;
   if (data) req.send(data);
   if (fn) req.end(fn);
   return req;
@@ -1487,9 +1487,9 @@ require.alias("component-emitter/index.js", "emitter/index.js");
 require.alias("component-reduce/index.js", "superagent/deps/reduce/index.js");
 require.alias("component-reduce/index.js", "reduce/index.js");
 
-require.alias("superagent/lib/client.js", "superagent/index.js");if (typeof exports == "object") {
+require.alias("superagent/lib/client.js", "superagent/index.js");if (typeof exports === "object") {
   module.exports = require("superagent");
-} else if (typeof define == "function" && define.amd) {
+} else if (typeof define === "function" && define.amd) {
   define([], function(){ return require("superagent"); });
 } else {
   this["superagent"] = require("superagent");

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,7 @@ export default function slackin({
     // convert to an array
     channels = channels.split(',').map((channel) => {
       // sanitize channel name
-      if ('#' == channel[0]) return channel.substr(1);
+      if ('#' === channel[0]) return channel.substr(1);
       return channel;
     });
   }

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -82,7 +82,7 @@ export default class SlackData extends EventEmitter {
 
     let total = users.length;
     let active = users.filter(user => {
-      return 'active' == user.presence;
+      return 'active' === user.presence;
     }).length;
 
     if (this.users) {


### PR DESCRIPTION
Non-slackin code may postMessage() to the same window (in my case, a
Twitter button), and unlike slackin, may choose to send an object as a
message rather than a string. Unlike strings, not all objects have a
.substr() method, so slackin doing e.data.substr() throws an exception:
[![jsbin showing exception thrown by slackin after a postMessage()](https://git.io/v2N5t)](http://jsbin.com/gojudi/edit?html,output)