### PR TITLE
Fix TypeError regression when submitting form without optional SLACK_CHANNELS config

### DIFF
--- a/lib/assets/client.js
+++ b/lib/assets/client.js
@@ -19,7 +19,7 @@ body.addEventListener('submit', function(ev){
   button.disabled = true;
   button.className = '';
   button.innerHTML = 'Please Wait';
-  invite(channel.value, coc && coc.checked ? 1 : 0, email.value, function(err, msg){
+  invite(channel ? channel.value : null, coc && coc.checked ? 1 : 0, email.value, function(err, msg){
     if (err) {
       button.removeAttribute('disabled');
       button.className = 'error';


### PR DESCRIPTION
Introduced with the merge of https://github.com/rauchg/slackin/pull/152/ and the [release of v0.8.3](https://github.com/rauchg/slackin/compare/0.8.2...0.8.3).

**Fixes https://github.com/rauchg/slackin/issues/165**

The problem was if the `SLACK_CHANNELS` environment variable wasn't configured, then [no hidden form element](https://github.com/nickstenning/slackin/blob/ae93c74d32a1c1ddad79d96369394be3811c1608/lib/splash.js#L25) with the listed channels would be included. Therefore, our [`channel` variable would be `undefined`](https://github.com/nickstenning/slackin/blob/ae93c74d32a1c1ddad79d96369394be3811c1608/lib/assets/client.js#L22), and a direct access of the `value` property would throw an error.

Or perhaps there was something wrong on my end… just let me know if this PR isn't helpful :grinning: 

## How to test

Manually run the app without a `SLACK_CHANNELS` config and very that you can submit the form. I'm curious to know of any tips on adding an automated test to catch this, but it didn't look like there was anything around `client.js`.

Thanks for such a great project!