### PR TITLE
Update Dockerfile to Use the Code of Conduct Environment Variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN npm install --unsafe-perm
 
 EXPOSE 3000
 
-CMD ./bin/slackin --channels "$SLACK_CHANNELS" --port $PORT $SLACK_SUBDOMAIN $SLACK_API_TOKEN
+CMD ./bin/slackin --coc "$SLACK_COC" --channels "$SLACK_CHANNELS" --port $PORT $SLACK_SUBDOMAIN $SLACK_API_TOKEN


### PR DESCRIPTION
Currently, the Procfile is configured to allow the Code of Conduct flag, but the Dockerfile is not. This causes issues with tools like Dokku that automatically use the Dockerfile over a Procfile. This update adds parity between the two.