### PR TITLE
Add context to send oneself email for joining a Slack team

### DIFF
--- a/lib/splash.js
+++ b/lib/splash.js
@@ -8,18 +8,10 @@ export default function splash({ name, org, logo, active, total, channels, ifram
       dom('.logo.slack')
     ),
     dom('p',
-      'Join ', dom('b', name),
+      'To join ', dom('b', name),
       // mention single single-channel inline
       channels && channels.length === 1 && dom('span', ' #', channels[0]),
-      ' on Slack.'
-    ),
-    dom('p.status',
-      active
-        ? [
-          dom('b.active', active), ' users online now of ',
-          dom('b.total', total), ' registered.'
-        ]
-        : [dom('b.total', total), ' users are registered so far.']
+      ' on Slack, send yourself an invite from here.'
     ),
     dom('form',
       // channel selection when there are multiple
@@ -31,6 +23,14 @@ export default function splash({ name, org, logo, active, total, channels, ifram
       dom('input.form-item type=email placeholder=you@yourdomain.com '
         + (!iframe ? 'autofocus' : '')),
       dom('button.loading', 'Get my Invite')
+    ),
+    dom('p.status',
+      active
+        ? [
+          dom('b.active', active), ' users online now of ',
+          dom('b.total', total), ' registered.'
+        ]
+        : [dom('b.total', total), ' users are registered so far.']
     ),
     !iframe && dom('p.signin',
       'or ',


### PR DESCRIPTION
We have a small blurb about ourselves on the back of our conference kit (brochures, file folders etc) and that blurb says we hangout on Slack and that people can join us on our Slack by visiting friends.hasgeek.com. 

That page doesn't have much context on why there is another added step of sending oneself an email invite to join the actual slack team at friendsofhasgeek.slack.com, so I moved around some paragraphs and edited slackin's default text.