### PR TITLE
Change heroku deploy to master

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,7 +21,7 @@ Read more about the [motivations and history](http://rauchg.com/slackin) behind 
 
 #### Heroku
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/rauchg/slackin/tree/0.8.3)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/rauchg/slackin/tree/master)
 
 #### Azure
 


### PR DESCRIPTION
The current heroku button doesn't work due to #164, #165 and #167

The current "doesn't work with free slacks" bug is still alive on 0.8.3 this lets idiot users like me use master until there's a tag for a branch that works.