### PR TITLE
support linking to a preselected channel

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -106,7 +106,7 @@ Done in Markdown this looks like:
 
 [![](https://cldup.com/WIbawiqp0Q.png)](http://slack.socket.io)
 
-Point to `https://slack.yourdomain.com`.
+Point to `https://slack.yourdomain.com`. If you're only allowing single-channel guests, you can also link to `https://slack.yourdomain.com/?channel=<name>` to have them join that particular channel.
 
 **Note:** the image for the logo of the landing page
 is retrieved from the Slack API. If your organization
@@ -136,8 +136,8 @@ By default logging is enabled.
 
 ## Developing
 
-Slackin's server side code is written in ES6. It uses babel to transpile the 
-ES6 code to a format node understands. After cloning Slackin, you should 
+Slackin's server side code is written in ES6. It uses babel to transpile the
+ES6 code to a format node understands. After cloning Slackin, you should
 install the prerequisite node libraries with npm:
 
 ```bash
@@ -145,7 +145,7 @@ $ npm install
 ```
 
 After the libraries install, the postinstall script will run `gulp` to invoke
-babel on the source. It is important to run `gulp` manually after updating any 
+babel on the source. It is important to run `gulp` manually after updating any
 files in lib/ to update the versions in node/.
 
 ## Credits

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,20 @@ import splash from './splash';
 import iframe from './iframe';
 import log from './log';
 
+export function restrictChannels(channels, req) {
+  let channelName = req.query.channel;
+  if (
+    channels &&
+    channels.length > 0 &&
+    channelName &&
+    channels.indexOf(channelName) > -1
+  ) {
+    return [channelName];
+  } else {
+    return channels;
+  }
+}
+
 export default function slackin({
   token,
   interval = 5000, // jshint ignore:line
@@ -65,6 +79,7 @@ export default function slackin({
     let { name, logo } = slack.org;
     let { active, total } = slack.users;
     if (!name) return res.send(404);
+    let restrictedChannels = restrictChannels(channels, req);
     let page = dom('html',
       dom('head',
         dom('title',
@@ -74,7 +89,7 @@ export default function slackin({
         dom('link rel="shortcut icon" href=https://slack.global.ssl.fastly.net/272a/img/icons/favicon-32.png'),
         css && dom('link rel=stylesheet', { href: css })
       ),
-      splash({ coc, path, css, name, org, logo, channels, active, total })
+      splash({ coc, path, css, name, org, logo, active, total, channels: restrictedChannels })
     );
     res.type('html');
     res.send(page.toHTML());

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,31 @@
+import assert from 'assert';
 import nock from 'nock';
 import request from 'supertest';
-import slackin from '../lib/index';
+import slackin, { restrictChannels } from '../lib/index';
 
 describe('slackin', () => {
+  describe('.restrictChannels()', () => {
+    it("returns the same list when the query is empty", () => {
+      let results = restrictChannels(['foo', 'bar'], {query: {}});
+      assert.deepEqual(results, ['foo', 'bar']);
+    });
+
+    it("returns the same list when the channel isn't in the list", () => {
+      let results = restrictChannels(['foo', 'bar'], {query: {channel: 'baz'}});
+      assert.deepEqual(results, ['foo', 'bar']);
+    });
+
+    it("returns undefined when there are no channels to restrict", () => {
+      let results = restrictChannels(undefined, {query: {channel: 'foo'}});
+      assert.equal(results, undefined);
+    });
+
+    it("returns undefined when there is an empty list of channels to restrict", () => {
+      let results = restrictChannels([], {query: {channel: 'foo'}});
+      assert.deepEqual(results, []);
+    });
+  });
+
   describe('POST /invite', () => {
     beforeEach(() => {
       nock('https://myorg.slack.com')


### PR DESCRIPTION
Closes #111.

At 18F, we often include something like the following in a project README:

> To chat about this project, go to https://chat.18f.gov and select `such-and-such` from the dropdown.

Unfortunately, the latter direction often gets missed, and people end up joining the first channel listed. This pull request would allow the projects to link directly to their channel, avoiding the problem completely.

Instead of @mattgorecki's client-side [solution](https://github.com/rauchg/slackin/issues/111#issuecomment-168561742), I opted to do the channel selection server-side so that they don't even see the dropdown:

![screen shot 2016-04-12 at 11 27 24 pm](https://cloud.githubusercontent.com/assets/86842/14482023/2db8c18c-0106-11e6-8bad-078c17131a69.png)

Let me know what you think!

/cc @konklone 