### PR TITLE
update options listed in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -56,18 +56,19 @@ The available options are:
 ```
 Usage: slackin [options] <team-id> <api-token>
 
-Options:
+  Options:
 
-  -h, --help                 output usage information
-  -V, --version              output the version number
-  -p, --port <port>          Port to listen on [$PORT or 3000]
-  -h, --hostname <hostname>  Hostname to listen on [$HOSTNAME or 0.0.0.0]
-  -c, --channels [<chan>]    One or more comma-separated channel names to allow single-channel guests [$SLACK_CHANNELS]
-  -c, --channel <chan>       Single channel guest invite (deprecated) [$SLACK_CHANNEL]
-  -i, --interval <int>       How frequently (ms) to poll Slack [$SLACK_INTERVAL or 5000]
-  -P, --path                 Path to serve slackin under
-  -s, --silent               Do not print out warns or errors
-  -c, --css <file>           Full URL to a custom CSS file to use on the main page
+    -h, --help                 output usage information
+    -V, --version              output the version number
+    -p, --port <port>          Port to listen on [$PORT or 3000]
+    -h, --hostname <hostname>  Hostname to listen on [$HOSTNAME or 0.0.0.0]
+    -c, --channels [<chan>]    One or more comma-separated channel names to allow single-channel guests [$SLACK_CHANNELS]
+    -c, --channel <chan>       Single channel guest invite (deprecated) [$SLACK_CHANNEL]
+    -i, --interval <int>       How frequently (ms) to poll Slack [$SLACK_INTERVAL or 5000]
+    -P, --path <path>          Path to serve slackin under
+    -s, --silent               Do not print out warns or errors
+    -C, --coc <coc>            Full URL to a CoC that needs to be agreed to
+    -c, --css <file>           Full URL to a custom CSS file to use on the main page
 ```
 
 **Important: if you use Slackin in single-channel mode, you'll only be


### PR DESCRIPTION
Minor change: I noticed the Code of Conduct option while looking at [the socket.io slackin](http://slack.socket.io/), but didn't see that option mentioned anywhere in the README. Turns out this option is present when you run `slackin`, but the README hadn't been updated with the option. The rest of the change is just whitespace, since I copied-and-pasted directly from the terminal output.