### PR TITLE
Update docs with more clear token generation info

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -49,7 +49,7 @@ $ slackin "your-team-id" "your-slack-token"
 
 Your team id is what you use to access your login page on Slack (eg: https://**{this}**.slack.com).
 
-You can find your API token at [api.slack.com/web](https://api.slack.com/web) – note that the user you use to generate the token must be an admin. You need to create a dedicated `@slackin-inviter` user (or similar), mark that user an admin, and use a token from that dedicated admin user.
+You can find or generate your API test token at [api.slack.com/web](https://api.slack.com/web) – note that the user you use to generate the token must be an admin. You need to create a dedicated `@slackin-inviter` user (or similar), mark that user an admin, and use a test token from that dedicated admin user.  Note that test tokens have actual permissions so you do not need to create an OAuth 2 app. Also check out the Slack docs on [generating a test token](https://get.slack.help/hc/en-us/articles/215770388-Creating-and-regenerating-API-tokens).
 
 The available options are:
 


### PR DESCRIPTION
As a new user of slackin I did not understand that I needed only a test token and that creating a whole OAuth 2 token was not needed and in fact would not work. This update the docs to be very clear that you should be using a test token with Slackin. Closes #178.