### PR TITLE
Fix startup and test suite issues following commit c54b678

### DIFF
--- a/bin/slackin
+++ b/bin/slackin
@@ -2,7 +2,7 @@
 
 var pkg = require('./../package');
 var args = require('args');
-var slackin = require('./../node').default;
+var slackin = require('./../dist').default;
 
 args
   .option(['p', 'port'], 'Port to listen on [$PORT or 3000]', require('hostenv').PORT || process.env.PORT || 3000)

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "license": "MIT",
   "devDependencies": {
     "babel-eslint": "6.0.4",
+    "babel-register": "^6.9.0",
     "eslint": "2.12.0",
     "eslint-config-default": "0.2.0",
     "mocha": "2.2.4",


### PR DESCRIPTION
1. https://github.com/rauchg/slackin/issues/203 Updates the location of the slackin library to point to the new `dist` directory (the `node` directory was removed on commit c54b678).
2. Adds the babel-register package to `devDependencies`. Without this package installed running `npm test` fails.