### PR TITLE
Important bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Usage: slackin [options] <team-id> <api-token>
 Options:
 
   -h, --help                 output usage information
-  -V, --version              output the version number
+  -v, --version              output the version number
   -p, --port <port>          Port to listen on [$PORT or 3000]
-  -h, --hostname <hostname>  Hostname to listen on [$HOSTNAME or 0.0.0.0]
+  -H, --hostname <hostname>  Hostname to listen on [$HOSTNAME or 0.0.0.0]
   -c, --channels [<chan>]    One or more comma-separated channel names to allow single-channel guests [$SLACK_CHANNELS]
   -c, --channel <chan>       Single channel guest invite (deprecated) [$SLACK_CHANNEL]
   -i, --interval <int>       How frequently (ms) to poll Slack [$SLACK_INTERVAL or 5000]

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ Usage: slackin [options] <team-id> <api-token>
 
 Options:
 
-  -h, --help                 output usage information
+  -?, --help                 output usage information
   -v, --version              output the version number
   -p, --port <port>          Port to listen on [$PORT or 3000]
-  -H, --hostname <hostname>  Hostname to listen on [$HOSTNAME or 0.0.0.0]
+  -h, --hostname <hostname>  Hostname to listen on [$HOSTNAME or 0.0.0.0]
   -c, --channels [<chan>]    One or more comma-separated channel names to allow single-channel guests [$SLACK_CHANNELS]
   -c, --channel <chan>       Single channel guest invite (deprecated) [$SLACK_CHANNEL]
   -i, --interval <int>       How frequently (ms) to poll Slack [$SLACK_INTERVAL or 5000]

--- a/bin/slackin
+++ b/bin/slackin
@@ -2,7 +2,7 @@
 
 var pkg = require('./../package');
 var args = require('args');
-var slackin = require('./../node').default;
+var slackin = require('./../dist').default;
 
 args
   .option(['p', 'port'], 'Port to listen on [$PORT or 3000]', require('hostenv').PORT || process.env.PORT || 3000)

--- a/bin/slackin
+++ b/bin/slackin
@@ -6,7 +6,7 @@ var slackin = require('./../node').default;
 
 args
   .option(['p', 'port'], 'Port to listen on [$PORT or 3000]', require('hostenv').PORT || process.env.PORT || 3000)
-  .option(['h', 'hostname'], 'Hostname to listen on [$HOSTNAME or 0.0.0.0]', require('hostenv').HOSTNAME || process.env.WEBSITE_HOSTNAME || '0.0.0.0')
+  .option(['H', 'hostname'], 'Hostname to listen on [$HOSTNAME or 0.0.0.0]', require('hostenv').HOSTNAME || process.env.WEBSITE_HOSTNAME || '0.0.0.0')
   .option(['c', 'channels'], 'One or more comma-separated channel names to allow single-channel guests [$SLACK_CHANNELS]', process.env.SLACK_CHANNELS)
   .option(['i', 'interval'], 'How frequently (ms) to poll Slack [$SLACK_INTERVAL or 5000]', process.env.SLACK_INTERVAL || 5000)
   .option(['P', 'path'], 'Path to serve slackin under', '/')

--- a/bin/slackin
+++ b/bin/slackin
@@ -6,20 +6,26 @@ var slackin = require('./../dist').default;
 
 args
   .option(['p', 'port'], 'Port to listen on [$PORT or 3000]', require('hostenv').PORT || process.env.PORT || 3000)
-  .option(['H', 'hostname'], 'Hostname to listen on [$HOSTNAME or 0.0.0.0]', require('hostenv').HOSTNAME || process.env.WEBSITE_HOSTNAME || '0.0.0.0')
+  .option(['h', 'hostname'], 'Hostname to listen on [$HOSTNAME or 0.0.0.0]', require('hostenv').HOSTNAME || process.env.WEBSITE_HOSTNAME || '0.0.0.0')
   .option(['c', 'channels'], 'One or more comma-separated channel names to allow single-channel guests [$SLACK_CHANNELS]', process.env.SLACK_CHANNELS)
   .option(['i', 'interval'], 'How frequently (ms) to poll Slack [$SLACK_INTERVAL or 5000]', process.env.SLACK_INTERVAL || 5000)
   .option(['P', 'path'], 'Path to serve slackin under', '/')
   .option(['s', 'silent'], 'Do not print out warns or errors')
   .option(['C', 'coc'], 'Full URL to a CoC that needs to be agreed to')
-  .option(['S', 'css'], 'Full URL to a custom CSS file to use on the main page');
+  .option(['S', 'css'], 'Full URL to a custom CSS file to use on the main page')
+  .option(['?', 'help'], 'Show the usage information');
 
 var flags = args.parse(process.argv, {
-  value: '<team-id> <api-token>'
+  value: '<team-id> <api-token>',
+  help: false
 });
 
 var org = args.sub[0] || process.env.SLACK_SUBDOMAIN;
 var token = args.sub[1] || process.env.SLACK_API_TOKEN;
+
+if (flags.help) {
+  args.showHelp();
+}
 
 if (!org || !token) {
   args.showHelp();

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ]
   },
   "dependencies": {
-    "args": "1.2.1",
+    "args": "1.3.0",
     "babel-core": "6.3.26",
     "babel-polyfill": "6.3.14",
     "babel-preset-es2015": "6.3.13",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "license": "MIT",
   "devDependencies": {
     "babel-eslint": "6.0.4",
+    "babel-register": "6.9.0",
     "eslint": "2.12.0",
     "eslint-config-default": "0.2.0",
     "mocha": "2.2.4",


### PR DESCRIPTION
- Allows developers to use the `-h` flag for the hostname again (caused problems because it made the help pop up: https://github.com/rauchg/slackin/issues/206)
- Renamed the path to the build output directory (fixes https://github.com/rauchg/slackin/issues/203)
- Like suggested by @alexpls, the devDependency "babel-register" has been added. That means, [this PR](https://github.com/rauchg/slackin/pull/204) can be closed in favour of this one.