### PR TITLE
Allow Let's Encrypt ACME challenge requests in Azure/IIS

### DIFF
--- a/web.config
+++ b/web.config
@@ -23,6 +23,12 @@
             </conditions>
             <action type="Redirect" url="https://{SERVER_NAME}/{R:1}" redirectType="Permanent" />
         </rule>
+        
+        <!-- Allow Let's Encrypt ACME challange requests -->
+	   <rule name="LetsEncryptAcmeChallange" stopProcessing="true">
+               <match url="^\.well-known.*$" />
+               <action type="None" />
+        </rule>
                   
         <!-- Do not interfere with requests for node-inspector debugging -->
         <rule name="NodeInspector" patternSyntax="ECMAScript" stopProcessing="true">

--- a/web.config
+++ b/web.config
@@ -24,8 +24,8 @@
             <action type="Redirect" url="https://{SERVER_NAME}/{R:1}" redirectType="Permanent" />
         </rule>
         
-        <!-- Allow Let's Encrypt ACME challange requests -->
-	   <rule name="LetsEncryptAcmeChallange" stopProcessing="true">
+        <!-- Allow Let's Encrypt ACME challenge requests -->
+	   <rule name="LetsEncryptAcmeChallenge" stopProcessing="true">
                <match url="^\.well-known.*$" />
                <action type="None" />
         </rule>


### PR DESCRIPTION
This pull request will allow static file requests to slackin-installation.com/.well-known/acme-challenge/STATIC_FILE which Let's Encrypt (https://letsencrypt.org/) uses to verify domain ownership when automatically issuing and renewing certs for HTTPS.

This change only changes web.config so it only works on Azure or other IIS-based hosts. **A better change would probably be to make Node itself serve the directory correctly** but my few tries to do that failed.

This change works like a charm together with the Azure Let's Encrypt extension (https://github.com/sjkp/letsencrypt-siteextension) which takes care of the Let's Encrypt setup. 

I've used it successfully on this site: https://www.fpv-sverige.se/ 
Which now lets through request like this one: https://www.fpv-sverige.se/.well-known/acme-challenge/1paIJkZJOxMjch3FHasm9xBGFqdrUopegAeaee_Cgyc
Before this fix node would just respond with CANNOT GET /path
