### PR TITLE
Switch from pure document.body for badge flyout Firefox compatibility.

### DIFF
--- a/lib/assets/badge.js
+++ b/lib/assets/badge.js
@@ -180,8 +180,8 @@
       var iframePos = iframe.getBoundingClientRect()
       var divHeight = divPos.height + arrowHeight
 
-      var st = document.body.scrollTop
-      var sl = document.body.scrollLeft
+      var st = document.documentElement.scrollTop
+      var sl = document.documentElement.scrollLeft
       var iw = window.innerWidth
       var ih = window.innerHeight
       var iframeTop = iframePos.top + st

--- a/lib/assets/badge.js
+++ b/lib/assets/badge.js
@@ -180,8 +180,8 @@
       var iframePos = iframe.getBoundingClientRect()
       var divHeight = divPos.height + arrowHeight
 
-      var st = document.documentElement.scrollTop
-      var sl = document.documentElement.scrollLeft
+      var st = window.scrollY || document.body.scrollTop
+      var sl = window.scrollX || document.body.scrollLeft
       var iw = window.innerWidth
       var ih = window.innerHeight
       var iframeTop = iframePos.top + st


### PR DESCRIPTION
This fixes #182, where Firefox's flyout was positioned opposite scroll.