### PR TITLE
Fix for #201 by adding defensive statement

### DIFF
--- a/lib/slack.js
+++ b/lib/slack.js
@@ -70,7 +70,7 @@ export default class SlackData extends EventEmitter {
 
     let users = res.body.members
 
-    if (!users) {
+    if (!users || (users && !users.length)) {
       let err = new Error(`Invalid Slack response: ${res.status}`)
       this.emit('error', err)
       return this.retry()


### PR DESCRIPTION
My best guess here is that Slack's own API occasionally returns a members object that isn't what we expect it to be.

We tested with this defensive check and our slackin instance has been up for two weeks, a new record for us.

Fixes #201 