### PR TITLE
Switch to node:slim for Dockerfile base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM octohost/nodejs
+FROM node:slim
 
 ENV PORT 3000
 


### PR DESCRIPTION
This change was motivated by the following error encountered when running the image built using the pre-existing `octohost/nodejs`-based Dockerfile:

```
$ docker run --rm vdice/slackin:octohost-base sh -c './bin/slackin --version'

/srv/www/node_modules/args/dist/index.js:39
class Args {
^^^^^
SyntaxError: Unexpected reserved word
    at Module._compile (module.js:439:25)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/srv/www/bin/slackin:4:12)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
```

Whereas the image built off of the official `node:slim` variant (change in this PR) works great:
```
$ docker run --rm vdice/slackin:node-slim-base sh -c './bin/slackin --version'
0.13.0
```

A nice reduction of final image size is achieved as a bonus:
```
$ docker images | grep slackin
vdice/slackin                     node-slim-base      daef1e94ba1a        5 minutes ago       278.7 MB
vdice/slackin                     octohost-base       c74c39eadc07        7 minutes ago       589.3 MB
```