### PR TITLE
Adding support to use environment variable to filter email inviting

### DIFF
--- a/bin/slackin
+++ b/bin/slackin
@@ -23,6 +23,7 @@ var flags = args.parse(process.argv, {
 
 var org = args.sub[0] || process.env.SLACK_SUBDOMAIN
 var token = args.sub[1] || process.env.SLACK_API_TOKEN
+var emails = process.env.EMAIL_SLACK_LIST || ''
 
 if (flags.help) {
   args.showHelp()
@@ -33,6 +34,7 @@ if (!org || !token) {
 } else {
   flags.org = org
   flags.token = token
+  flags.emails = emails
 }
 
 var port = flags.port

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,6 +27,7 @@ export default function slackin ({
   cors: useCors = false,
   path='/',
   channels,
+  emails,
   silent = false // jshint ignore:line,
 }){
   // must haves
@@ -40,6 +41,11 @@ export default function slackin ({
       if ('#' === channel[0]) return channel.substr(1)
       return channel
     })
+  }
+
+  if (emails) {
+    // convert to an array
+    emails = emails.split(',')
   }
 
   // setup app
@@ -135,6 +141,13 @@ export default function slackin ({
       return res
       .status(400)
       .json({ msg: 'Invalid email' })
+    }
+
+    // Restricting email invites?
+    if (emails && emails.indexOf(email) === -1) {
+      return res
+      .status(400)
+      .json({ msg: 'Your email is not on the accepted email list' })
     }
 
     if (coc && '1' != req.body.coc) {


### PR DESCRIPTION
Using `EMAIL_SLACK_LIST` to get an optional email list to filter user invites. This is useful for conferences and other spaces where you have a list of attendees and you don't want anybody else so get into slack.

This was used on slack.jsconf.co 💃 