### PR TITLE
Show better error when slack subdomain incorrect

### DIFF
--- a/lib/slack.js
+++ b/lib/slack.js
@@ -21,6 +21,9 @@ export default class SlackData extends EventEmitter {
     .get(`https://${this.host}.slack.com/api/channels.list`)
     .query({ token: this.token })
     .end((err, res) => {
+      if (err) {
+        throw err;
+      }
       (res.body.channels || []).forEach(channel => {
         this.channelsByName[channel.name] = channel
       })


### PR DESCRIPTION
e.g when `SLACK_SUBDOMAIN="<zeit-community>"` following error would show up:
```
/home/nowuser/src/dist/slack.js:53
        (res.body.channels || []).forEach(function (channel) {
            ^
TypeError: Cannot read property 'body' of undefined
```

When really `err` is populated and contains real error.