### PR TITLE
Updating Slack API token URL.

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,7 +10,7 @@
       "required": true
     },
     "SLACK_API_TOKEN": {
-      "description": "A Slack API token (find it on https://api.slack.com/web)",
+      "description": "A Slack API token (find it on https://api.slack.com/custom-integrations/legacy-tokens)",
       "required": true
     },
     "GOOGLE_CAPTCHA_SECRET": {


### PR DESCRIPTION
**Issue**
The previous version provided an outdated URL (_https://api.slack.com/web_).

**Solution**
The URL has been updated to the appropriate endpoint (_https://api.slack.com/custom-integrations/legacy-tokens_).
