### PR TITLE
Require a more recent version of Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "supertest": "0.15.0"
   },
   "engines": {
-    "node": "4.5.0"
+    "node": "4.8.4"
   },
   "bin": {
     "slackin": "./bin/slackin"


### PR DESCRIPTION
Otherwise a vulnerable version of Node will be used to run the app.

Cf. https://nodejs.org/en/blog/vulnerability/july-2017-security-releases/