### PR TITLE
Add reCAPTCHA support to the badge/iframe version

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -245,9 +245,14 @@ export default function slackin ({
     let { name } = slack.org
     let { active, total } = slack.users
     if (!name) return res.send(404)
-    let dom = splash({ coc, path, name, org, channels, active, total, large, iframe: true })
+    let page = dom('html',
+      dom('head',
+        dom("script src=https://www.google.com/recaptcha/api.js")
+      ),
+      splash({ coc, path, name, org, channels, active, total, large, gcaptcha_sitekey, iframe: true })
+    )
     res.type('html')
-    res.send(dom.toHTML())
+    res.send(page.toHTML())
   })
 
   app.get('/.well-known/acme-challenge/:id', (req, res) => {


### PR DESCRIPTION
It appears that the reCAPTCHA support added in #311 ignored the badge/iframe version of slackin, and as it stands at the moment the badge version is unusable (see https://github.com/rauchg/slackin/pull/311#issuecomment-320101621). This is a problem for people wanting to update their Heroku apps because of the Node vulnerability.

This is a start at fixing it, but I'm not exactly sure how we can even support it in an iframe popup? For example:

<img width="289" alt="hrmm" src="https://user-images.githubusercontent.com/153/28986501-3ada0152-7935-11e7-8f7f-2f791c2a74f1.png">

- [x] Get recaptcha showing in the iframe version
- [ ] Figure out what to do