### PR TITLE
Add self-hosting instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,12 @@ Other platforms:
 - [OpenShift](https://github.com/rauchg/slackin/wiki/OpenShift)
 - [IBM Bluemix](https://bluemix.net/deploy?repository=https://github.com/rauchg/slackin)
 
+To host Slackin yourself, install it via npm and launch it on your server:
+```
+$ npm install -g slackin
+$ slackin "your-team-id" "your-slack-token"
+```
+
 ### Tips
 
 Your team id is what you use to access your login page on Slack (eg: https://**{this}**.slack.com).


### PR DESCRIPTION
Pretty strange that this was missing... It's documented on the npm page (https://yarnpkg.com/en/package/slackin) but not everyone would think to look there.