### PR TITLE
fix: ignore dist/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 
 # logs
 npm-debug.log
+
+dist


### PR DESCRIPTION
Will prevent the `dist` directory from being committed, as it is compiled Javascript.