### PR TITLE
fix: vulnerable packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,78 +1,78 @@
 {
-  "name": "slackin",
-  "version": "0.14.0",
-  "description": "Public Slack organizations made easy",
-  "repository": "rauchg/slackin",
-  "main": "dist/index",
-  "files": [
-    "dist",
-    "bin"
-  ],
-  "babel": {
-    "presets": [
-      "es2015"
-    ]
-  },
-  "dependencies": {
-    "args": "1.3.0",
-    "babel-core": "6.3.26",
-    "babel-eslint": "6.0.4",
-    "babel-polyfill": "6.3.14",
-    "babel-preset-es2015": "6.3.13",
-    "babel-register": "6.9.0",
-    "body-parser": "1.10.2",
-    "cors": "2.7.1",
-    "debug": "2.1.1",
-    "email-regex": "1.0.0",
-    "express": "4.11.0",
-    "gulp-babel": "6.1.1",
-    "gulp-rimraf": "0.2.0",
-    "gulp": "3.9.0",
-    "hostenv": "1.0.1",
-    "opentype.js": "0.4.4",
-    "socket.io": "1.4.8",
-    "superagent": "0.21.0",
-    "vd": "0.1.0"
-  },
-  "license": "MIT",
-  "devDependencies": {
-    "eslint": "2.12.0",
-    "eslint-config-default": "0.2.0",
-    "mocha": "2.2.4",
-    "nock": "2.17.0",
-    "supertest": "0.15.0"
-  },
-  "engines": {
-    "node": "6.11.1"
-  },
-  "bin": {
-    "slackin": "./bin/slackin"
-  },
-  "eslintConfig": {
-    "extends": "default",
-    "parser": "babel-eslint",
-    "rules": {
-      "no-var": 0
-    }
-  },
-  "scripts": {
-    "test": "mocha && eslint lib/**",
-    "postinstall": "gulp",
-    "build": "gulp",
-    "start": "chmod +x bin/slackin && ./bin/slackin"
-  },
-  "now": {
-    "type": "npm",
+    "name": "slackin",
+    "version": "0.14.0",
+    "description": "Public Slack organizations made easy",
+    "repository": "rauchg/slackin",
+    "main": "dist/index",
     "files": [
-      "bin",
-      "lib",
-      "gulpfile.babel.js"
+        "dist",
+        "bin"
     ],
-    "env": [
-      "SLACK_API_TOKEN",
-      "SLACK_SUBDOMAIN",
-      "GOOGLE_CAPTCHA_SECRET",
-      "GOOGLE_CAPTCHA_SITEKEY"
-    ]
-  }
+    "babel": {
+        "presets": [
+            "es2015"
+        ]
+    },
+    "dependencies": {
+        "args": "1.3.0",
+        "babel-core": "6.3.26",
+        "babel-eslint": "6.0.4",
+        "babel-polyfill": "6.3.14",
+        "babel-preset-es2015": "6.3.13",
+        "babel-register": "6.9.0",
+        "body-parser": "1.10.2",
+        "cors": "2.7.1",
+        "debug": "3.0.1",
+        "email-regex": "1.0.0",
+        "express": "4.15.4",
+        "gulp-babel": "6.1.1",
+        "gulp-rimraf": "0.2.0",
+        "gulp": "3.9.0",
+        "hostenv": "1.0.1",
+        "opentype.js": "0.4.4",
+        "socket.io": "2.0.3",
+        "superagent": "3.6.0",
+        "vd": "0.1.0"
+    },
+    "license": "MIT",
+    "devDependencies": {
+        "eslint": "2.12.0",
+        "eslint-config-default": "0.2.0",
+        "mocha": "2.2.4",
+        "nock": "2.17.0",
+        "supertest": "0.15.0"
+    },
+    "engines": {
+        "node": "6.11.1"
+    },
+    "bin": {
+        "slackin": "./bin/slackin"
+    },
+    "eslintConfig": {
+        "extends": "default",
+        "parser": "babel-eslint",
+        "rules": {
+            "no-var": 0
+        }
+    },
+    "scripts": {
+        "test": "mocha && eslint lib/**",
+        "postinstall": "gulp",
+        "build": "gulp",
+        "start": "chmod +x bin/slackin && ./bin/slackin"
+    },
+    "now": {
+        "type": "npm",
+        "files": [
+            "bin",
+            "lib",
+            "gulpfile.babel.js"
+        ],
+        "env": [
+            "SLACK_API_TOKEN",
+            "SLACK_SUBDOMAIN",
+            "GOOGLE_CAPTCHA_SECRET",
+            "GOOGLE_CAPTCHA_SITEKEY"
+        ]
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/rauchg/slackin/issues/328 ([for security purposes](https://snyk.io/test/npm/slackin/0.13.0)).

* `socket.io` : _1.4.8_ => ___2.0.3___ (or at least ___1.7.4___)
* `express` : _4.11.0_ => ___4.15.4___
* `superagent` : _0.21.0_ => ___3.6.0___
* `debug` : _2.1.1_ => ___3.0.1___
