### PR TITLE
Fix signup via badges

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -245,9 +245,12 @@ export default function slackin ({
     let { name } = slack.org
     let { active, total } = slack.users
     if (!name) return res.send(404)
-    let dom = splash({ coc, path, name, org, channels, active, total, large, iframe: true })
+    let page = dom('html',
+      dom("script src=https://www.google.com/recaptcha/api.js"),
+      splash({ coc, path, name, org, channels, active, total, large, iframe: true, gcaptcha_sitekey })
+    )
     res.type('html')
-    res.send(dom.toHTML())
+    res.send(page.toHTML())
   })
 
   app.get('/.well-known/acme-challenge/:id', (req, res) => {

--- a/lib/splash.js
+++ b/lib/splash.js
@@ -342,5 +342,12 @@ function style ({ logo, active, large, iframe } = {}){
     })
   }
 
+  if (iframe) {
+    css.add('.g-recaptcha', {
+      'transform': 'scale(0.76)',
+      'transform-origin': '0 0',
+    })
+  }
+
   return css
 }


### PR DESCRIPTION
Signups via the badge go down a slightly different path than signups via the main page (eventually ending up at https://example.com/iframe/dialog, https://github.com/rauchg/slackin/blob/master/lib/index.js#L248). Unfortunately this path doesn't pass `gcaptcha_sitekey` to `splash` (https://github.com/rauchg/slackin/blob/master/lib/splash.js#L3) which results in this error when you try to sign up:

```
Uncaught TypeError: Cannot read property 'value' of undefined
    at HTMLBodyElement.<anonymous> (client.js:23)
```

The fix is to pass `gcaptcha_sitekey` which I have tested locally.