### PR TITLE
configurable ping interval to slack api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules
 
 # logs
 npm-debug.log
+
+# Env
+.env

--- a/bin/slackin
+++ b/bin/slackin
@@ -8,7 +8,7 @@ args
   .option(['p', 'port'], 'Port to listen on [$PORT or 3000]', require('hostenv').PORT || process.env.PORT || 3000)
   .option(['h', 'hostname'], 'Hostname to listen on [$HOSTNAME or 0.0.0.0]', require('hostenv').HOSTNAME || process.env.WEBSITE_HOSTNAME || '0.0.0.0')
   .option(['c', 'channels'], 'One or more comma-separated channel names to allow single-channel guests [$SLACK_CHANNELS]', process.env.SLACK_CHANNELS)
-  .option(['i', 'interval'], 'How frequently (ms) to poll Slack [$SLACK_INTERVAL or 5000]', process.env.SLACK_INTERVAL || 5000)
+  .option(['i', 'interval'], 'How frequently (ms) to poll Slack [$SLACK_INTERVAL or 15000]', process.env.SLACK_INTERVAL || 15000)
   .option(['P', 'path'], 'Path to serve slackin under', '/')
   .option(['s', 'silent'], 'Do not print out warns or errors')
   .option(['x', 'cors'], 'Enable CORS for all routes')

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ import log from './log'
 
 export default function slackin ({
   token,
-  interval = 5000, // jshint ignore:line
+  interval = 15000, // jshint ignore:line
   org,
   gcaptcha_secret,
   gcaptcha_sitekey,

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -7,7 +7,7 @@ export default class SlackData extends EventEmitter {
     super()
     this.host = host
     this.token = token
-    this.interval = interval
+    this.interval = interval < 5000 ? 15000 : interval // Prevent pings of less than 5sec intervals
     this.ready = false
     this.org = {}
     this.users = {}

--- a/package.json
+++ b/package.json
@@ -69,10 +69,12 @@
             "gulpfile.babel.js"
         ],
         "env": [
+            "SLACK_INTERVAL",
             "SLACK_API_TOKEN",
             "SLACK_SUBDOMAIN",
             "GOOGLE_CAPTCHA_SECRET",
             "GOOGLE_CAPTCHA_SITEKEY"
-        ]
+        ],
+        "dotenv": ".env"
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,25 @@ Other platforms:
 - [OpenShift](https://github.com/rauchg/slackin/wiki/OpenShift)
 - [IBM Bluemix](https://bluemix.net/deploy?repository=https://github.com/rauchg/slackin)
 
+### Environment Variables
+
+These environment variables can be used to configure the app.
+
+```bash
+# Time in milliseconds to ping the slack api
+SLACK_INTERVAL=15000
+
+# Slack team id (subdomain of slack.com)
+SLACK_SUBDOMAIN=
+
+# Slack api token of your slack app with admin permission
+SLACK_API_TOKEN=
+
+# Google reCAPTCHA keys
+GOOGLE_CAPTCHA_SITEKEY=
+GOOGLE_CAPTCHA_SECRET=
+```
+
 ### Tips
 
 Your team id is what you use to access your login page on Slack (eg: https://**{this}**.slack.com).


### PR DESCRIPTION
Changed default ping interval from 5sec to 15sec.
When deploying to 'now', prompt for SLACK_INTERVAL to allow users to change the default ping interval