### PR TITLE
fetch only when clients are connected

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -273,8 +273,10 @@ export default function slackin ({
     socket.emit('data', slack.users)
     let change = (key, val) => socket.emit(key, val)
     slack.on('change', change)
+    slack.clientConnected()
     socket.on('disconnect', () => {
       slack.removeListener('change', change)
+      slack.clientDisconnected()
     })
   })
 

--- a/lib/log.js
+++ b/lib/log.js
@@ -16,13 +16,18 @@ export default function log (slack, silent){
     out('fetching')
   })
 
+  slack.on('log', (message) => {
+    out(message)
+  })
+
   slack.on('data', online)
 
   // log online users
   function online (){
-    out('online %d, total %d %s',
+    out('online %d, total %d, clients %d %s',
       slack.users.active,
       slack.users.total,
+      slack.clientConnectionCount,
       last ? `(+${new Date - last}ms)` : '')
   }
 

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -12,7 +12,7 @@ export default class SlackData extends EventEmitter {
     this.org = {}
     this.users = {}
     this.clientConnectionCount = 0
-    this.fetchTimeout = nil 
+    this.fetchTimeout = null 
     this.channelsByName = {}
     this.init()
     this.fetch()

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -11,6 +11,8 @@ export default class SlackData extends EventEmitter {
     this.ready = false
     this.org = {}
     this.users = {}
+    this.clientConnectionCount = 0
+    this.fetchTimeout = nil 
     this.channelsByName = {}
     this.init()
     this.fetch()
@@ -44,7 +46,36 @@ export default class SlackData extends EventEmitter {
     })
   }
 
+  clientConnected() {
+    if (this.clientConnectionCount == 0) {
+      this.emit('log', 'restarting fetch')
+      this.fetch()
+    }
+    this.clientConnectionCount++
+  }
+
+  clientDisconnected() {
+    this.clientConnectionCount--
+    if (this.clientConnectionCount == 0) {
+      this.emit('log', 'pausing fetch')
+      this.stopFetchTimeout()
+    }
+  }
+
+  stopFetchTimeout() {
+    if (this.fetchTimeout) {
+      clearTimeout(this.fetchTimeout)
+      this.fetchTimeout = null
+    }
+  }
+
+  retryFetch(interval) {
+    this.stopFetchTimeout()
+    this.fetchTimeout = setTimeout(this.fetch.bind(this), interval)
+  }
+
   fetch (){
+    this.stopFetchTimeout()
     request
     .get(`https://${this.host}.slack.com/api/users.list`)
     .query({ token: this.token, presence: 1 })
@@ -59,9 +90,9 @@ export default class SlackData extends EventEmitter {
     return channel ? channel.id: null
   }
 
-  retry (){
+  retry () {
     let interval = this.interval * 2
-    setTimeout(this.fetch.bind(this), interval)
+    this.retryFetch(interval)
     this.emit('retry')
   }
 
@@ -107,7 +138,9 @@ export default class SlackData extends EventEmitter {
       this.emit('ready')
     }
 
-    setTimeout(this.fetch.bind(this), this.interval)
+    if (this.clientConnectionCount > 0) {
+      this.retryFetch(this.interval)
+    }
     this.emit('data')
   }
 


### PR DESCRIPTION
I noticed the server was actively pinging slack even when no one was visiting the service to see who was online. This will pause the regular ping to slack when there are no active clients. When a client reconnects, the regular fetch interval will continue. This will lighten the load on the server.