### PR TITLE
switch status string based on active count

### DIFF
--- a/lib/assets/client.js
+++ b/lib/assets/client.js
@@ -83,7 +83,7 @@ function update (val, n, noanim){
       el.innerHTML = n
       anim(el, val)
     }
-  }
+  })
 }
 
 function anim (el, c){

--- a/lib/assets/client.js
+++ b/lib/assets/client.js
@@ -68,11 +68,11 @@ socket.on('data', function (users){
 socket.on('total', function (n){ update('total', n) })
 socket.on('active', function (n){
   if (n > 0) {
-    document.querySelector('div.statusActive').className = 'statusActive'
-    document.querySelector('dvi.statusInactive').className = 'statusInactive hide'
+    document.querySelector('.statusActive').className = 'statusActive'
+    document.querySelector('.statusInactive').className = 'statusInactive hide'
   } else {
-    document.querySelector('div.statusActive').className = 'statusActive hide'
-    document.querySelector('dvi.statusInactive').className = 'statusInactive'
+    document.querySelector('.statusActive').className = 'statusActive hide'
+    document.querySelector('.statusInactive').className = 'statusInactive'
   }
   update('active', n)
 })

--- a/lib/assets/client.js
+++ b/lib/assets/client.js
@@ -66,13 +66,23 @@ socket.on('data', function (users){
   for (var i in users) update(i, users[i])
 })
 socket.on('total', function (n){ update('total', n) })
-socket.on('active', function (n){ update('active', n) })
+socket.on('active', function (n){
+  if (n > 0) {
+    document.querySelector('div.statusActive').className = 'statusActive'
+    document.querySelector('dvi.statusInactive').className = 'statusInactive hide'
+  } else {
+    document.querySelector('div.statusActive').className = 'statusActive hide'
+    document.querySelector('dvi.statusInactive').className = 'statusInactive'
+  }
+  update('active', n)
+})
 
 function update (val, n, noanim){
-  var el = document.querySelector('.' + val)
-  if (n != el.innerHTML) {
-    el.innerHTML = n
-    anim(el, val)
+  document.querySelectorAll('.' + val).forEach(function(el) {
+    if (n != el.innerHTML) {
+      el.innerHTML = n
+      anim(el, val)
+    }
   }
 }
 

--- a/lib/splash.js
+++ b/lib/splash.js
@@ -13,13 +13,13 @@ export default function splash ({ path, name, org, coc, logo, active, total, cha
       ' on Slack.'
     ),
     dom('p.status',
-      dom('span.' + (active ? 'statusActive' : 'statusActive hide'),
+      dom('span.' + (active ? 'statusActive' : 'statusActive.hide'),
         [
           dom('b.active', active), ' users online now of ',
           dom('b.total', total), ' registered.'
         ]
       ),
-      dom('span.' + (active ? 'statusInactive hide' : 'statusInactive'),
+      dom('span.' + (active ? 'statusInactive.hide' : 'statusInactive'),
         [
           dom('b.total', total), ' users are registered so far.'
         ]

--- a/lib/splash.js
+++ b/lib/splash.js
@@ -13,12 +13,19 @@ export default function splash ({ path, name, org, coc, logo, active, total, cha
       ' on Slack.'
     ),
     dom('p.status',
-      active
-        ? [
-          dom('b.active', active), ' users online now of ',
-          dom('b.total', total), ' registered.'
-        ]
-        : [dom('b.total', total), ' users are registered so far.']
+      [
+        dom('div.' + (active ? 'statusActive' : 'statusActive hide'),
+          [
+            dom('b.active', active), ' users online now of ',
+            dom('b.total', total), ' registered.'
+          ]
+        ),
+        dom('div.' + (active ? 'statusInactive hide' : 'statusInactive'),
+          [
+            dom('b.total', total), ' users are registered so far.'
+          ]
+        )
+      ]
     ),
     dom('form id=invite',
       channels && (
@@ -79,6 +86,10 @@ function style ({ logo, active, large, iframe } = {}){
     'margin': iframe ? '0' : '20rem auto',
     'text-align': 'center',
     'font-family': '"Helvetica Neue", Helvetica, Arial'
+  })
+
+  css.add('.hide', {
+    'display': 'none'
   })
 
   if (iframe) {

--- a/lib/splash.js
+++ b/lib/splash.js
@@ -13,19 +13,17 @@ export default function splash ({ path, name, org, coc, logo, active, total, cha
       ' on Slack.'
     ),
     dom('p.status',
-      [
-        dom('div.' + (active ? 'statusActive' : 'statusActive hide'),
-          [
-            dom('b.active', active), ' users online now of ',
-            dom('b.total', total), ' registered.'
-          ]
-        ),
-        dom('div.' + (active ? 'statusInactive hide' : 'statusInactive'),
-          [
-            dom('b.total', total), ' users are registered so far.'
-          ]
-        )
-      ]
+      dom('span.' + (active ? 'statusActive' : 'statusActive hide'),
+        [
+          dom('b.active', active), ' users online now of ',
+          dom('b.total', total), ' registered.'
+        ]
+      ),
+      dom('span.' + (active ? 'statusInactive hide' : 'statusInactive'),
+        [
+          dom('b.total', total), ' users are registered so far.'
+        ]
+      )
     ),
     dom('form id=invite',
       channels && (


### PR DESCRIPTION
When no one is online the text only contains the number of registered users. When someone comes online while the page is showing this text it will never switch to show the new online user. This change makes it so the online count in the splash page is displayed if the user loaded the page initially when no one was online.