### PR TITLE
Fix slackin

### DIFF
--- a/bin/slackin
+++ b/bin/slackin
@@ -6,7 +6,6 @@ var slackin = require('./../dist').default
 
 args
   .option(['p', 'port'], 'Port to listen on [$PORT or 3000]', require('hostenv').PORT || process.env.PORT || 3000)
-  .option(['h', 'hostname'], 'Hostname to listen on [$HOSTNAME or 0.0.0.0]', require('hostenv').HOSTNAME || process.env.WEBSITE_HOSTNAME || '0.0.0.0')
   .option(['c', 'channels'], 'One or more comma-separated channel names to allow single-channel guests [$SLACK_CHANNELS]', process.env.SLACK_CHANNELS)
   .option(['i', 'interval'], 'How frequently (ms) to poll Slack [$SLACK_INTERVAL or 5000]', process.env.SLACK_INTERVAL || 5000)
   .option(['P', 'path'], 'Path to serve slackin under', '/')
@@ -45,7 +44,7 @@ if (!org || !token || !gcaptcha_sitekey || !gcaptcha_secret) {
 }
 
 var port = flags.port
-var hostname = flags.hostname
+var hostname = '0.0.0.0'
 
 slackin(flags).listen(port, hostname, function (err) {
   if (err) throw err

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "supertest": "0.15.0"
     },
     "engines": {
-        "node": "6.11.1"
+        "node": "6.x.x"
     },
     "bin": {
         "slackin": "./bin/slackin"


### PR DESCRIPTION
Closes #379.

These changes are necessary in order for `now rauchg/slackin` to work.

The change to `engine` in package.json was derived from #379.

As for the change in `hostname`, I'm not sure why this is necessary.
All I know is that when attempting to deploy using `now`, it passes in
a bogus hostname. Hardcoding it to `0.0.0.0` fixes the issue (though
it's admittedly a hack.)