### PR TITLE
Update the IBM Cloud deployment option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ Other platforms:
 - [Heroku](https://heroku.com/deploy?template=https://github.com/rauchg/slackin/tree/master)
 - [Azure](https://azuredeploy.net/)
 - [OpenShift](https://github.com/rauchg/slackin/wiki/OpenShift)
-- [IBM Cloud](https://bluemix.net/deploy?repository=https://github.com/rauchg/slackin)
+- [IBM Cloud](https://cloud.ibm.com/devops/setup/deploy?repository=https://github.com/rauchg/slackin)
 
 ### Tips
 


### PR DESCRIPTION
This update fixes the DevOps URL options on IBM Cloud platform. All `bluemix.net` URLs are being replaced to `cloud.ibm.com`. Also, the DevOps URL has changed with this the new IBM Cloud URL.