### PR TITLE
Pinning node image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:slim
+FROM node:10-slim
 
 ENV PORT 3000
 


### PR DESCRIPTION
Node has moved on since this was created, and the version now needs pinning to maintain compatibility. As described in #404 .